### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -73,7 +73,7 @@ zip = whereis('zip')
 #
 date = ARGUMENTS.get('DATE')
 if not date:
-    date = time.strftime("%Y/%m/%d %H:%M:%S", time.localtime(time.time()))
+    date = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
 
 developer = ARGUMENTS.get('DEVELOPER')
 if not developer:

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -131,8 +131,9 @@ if skip_doc:
     if not os.path.isdir(scdir):
         os.makedirs(scdir)
 
-    import datetime
-    today = datetime.date.today().strftime("%m/%d/%Y")
+    import time
+    today = time.strftime("%Y-%m-%d",
+        time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
     version = env.subst('$VERSION')
     for m in man_page_list:
         man, _ = os.path.splitext(m)

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -162,6 +162,11 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       Three uses of variables not defined are changed.
     - Some script changes in trying to find scons engine
 
+  From Bernhard M. Wiedemann:
+    - Allow to override build date with SOURCE_DATE_EPOCH for SCons itself,
+      but not for software built with SCons.
+    - Datestamps in docs and embedded in code use ISO 8601 format and UTC
+
   From Hao Wu
     - typo in customized decider example in user guide
 


### PR DESCRIPTION
* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also consistently use ISO 8601 date format
to be understood everywhere.
Also use gmtime to be independent of timezone.