### PR TITLE
Issue #3283 fix md5 timestamp with config force second run exception

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,9 +7,13 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From John Doe:
+  From William Deegan:
 
-    - Whatever John Doe did.
+    - Fix Issue #3283 - Handle using --config=force in combination with Decider('MD5-timestamp').
+      3.0.2 in fix for issue #2980 added that deciders can throw DeciderNeedsNode exception.
+      The Configure logic directly calls the decider when using --config=force but wasn't handling
+      that exception.  This would yield minimally configure tests using TryLink() not running and
+      leaving TypeError Nonetype exception in config.log
 
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path

--- a/src/engine/SCons/Job.py
+++ b/src/engine/SCons/Job.py
@@ -199,7 +199,7 @@ class Serial(object):
                 task.prepare()
                 if task.needs_execute():
                     task.execute()
-            except:
+            except Exception as e:
                 if self.interrupted():
                     try:
                         raise SCons.Errors.BuildError(

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -56,6 +56,7 @@ import SCons.Warnings
 import SCons.Conftest
 
 from SCons.Debug import Trace
+from SCons.Node import DeciderNeedsNode
 
 # Turn off the Conftest error logging
 SCons.Conftest.LogInputFiles = 0
@@ -330,8 +331,14 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
                     # that the correct .sconsign info will get calculated
                     # and keep the build state consistent.
                     def force_build(dependency, target, prev_ni,
-                                    env_decider=env.decide_source):
-                        env_decider(dependency, target, prev_ni)
+                                    env_decider=env.decide_source,
+                                    node=None):
+                        try:
+                            env_decider(dependency, target, prev_ni)
+                        except DeciderNeedsNode as e:
+                            e.decider(target, prev_ni, node=target)
+                        except Exception as e:
+                            raise e
                         return True
                     if env.decide_source.__code__ is not force_build.__code__:
                         env.Decider(force_build)

--- a/test/Configure/option--config.py
+++ b/test/Configure/option--config.py
@@ -39,9 +39,9 @@ test = TestSCons.TestSCons()
 test.subdir('include')
 
 NCR = test.NCR  # non-cached rebuild
-CR  = test.CR   # cached rebuild (up to date)
+CR = test.CR  # cached rebuild (up to date)
 NCF = test.NCF  # non-cached build failure
-CF  = test.CF   # cached build failure
+CF = test.CF  # cached build failure
 
 SConstruct_path = test.workpath('SConstruct')
 
@@ -70,36 +70,36 @@ scons: *** "%(conftest_0_c)s" is not yet built and cache is forced.
 test.run(arguments='--config=cache', status=2, stderr=expect)
 
 test.run(arguments='--config=auto')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["yes", "no"],
-                    [[((".c", NCR), (_obj, NCR))],
-                     [((".c", NCR), (_obj, NCF))]],
-                    "config.log", ".sconf_temp", "SConstruct")
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["yes", "no"],
+                       [[((".c", NCR), (_obj, NCR))],
+                        [((".c", NCR), (_obj, NCF))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 test.run(arguments='--config=auto')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["yes", "no"],
-                    [[((".c", CR), (_obj, CR))],
-                     [((".c", CR), (_obj, CF))]],
-                    "config.log", ".sconf_temp", "SConstruct")
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["yes", "no"],
+                       [[((".c", CR), (_obj, CR))],
+                        [((".c", CR), (_obj, CF))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 test.run(arguments='--config=force')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["yes", "no"],
-                    [[((".c", NCR), (_obj, NCR))],
-                     [((".c", NCR), (_obj, NCF))]],
-                    "config.log", ".sconf_temp", "SConstruct")
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["yes", "no"],
+                       [[((".c", NCR), (_obj, NCR))],
+                        [((".c", NCR), (_obj, NCF))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 test.run(arguments='--config=cache')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["yes", "no"],
-                    [[((".c", CR), (_obj, CR))],
-                     [((".c", CR), (_obj, CF))]],
-                    "config.log", ".sconf_temp", "SConstruct")
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["yes", "no"],
+                       [[((".c", CR), (_obj, CR))],
+                        [((".c", CR), (_obj, CF))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 test.write(['include', 'non_system_header1.h'], """
 /* Another header */
@@ -107,21 +107,20 @@ test.write(['include', 'non_system_header1.h'], """
 test.unlink(['include', 'non_system_header0.h'])
 
 test.run(arguments='--config=cache')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["yes", "no"],
-                    [[((".c", CR), (_obj, CR))],
-                     [((".c", CR), (_obj, CF))]],
-                    "config.log", ".sconf_temp", "SConstruct")
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["yes", "no"],
+                       [[((".c", CR), (_obj, CR))],
+                        [((".c", CR), (_obj, CF))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 test.run(arguments='--config=auto')
-test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
-                    "Checking for C header file non_system_header1.h... "],
-                    ["no", "yes"],
-                    [[((".c", CR), (_obj, NCF))],
-                     [((".c", CR), (_obj, NCR))]],
-                    "config.log", ".sconf_temp", "SConstruct")
-
+test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
+                        "Checking for C header file non_system_header1.h... "],
+                       ["no", "yes"],
+                       [[((".c", CR), (_obj, NCF))],
+                        [((".c", CR), (_obj, NCR))]],
+                       "config.log", ".sconf_temp", "SConstruct")
 
 # Check the combination of --config=force and Decider('MD5-timestamp')
 # On second run there was an issue where the decider would throw DeciderNeedsNode
@@ -137,9 +136,7 @@ env = conf.Finish()
 test.run(arguments='--config=force')
 # On second run the sconsign is loaded and decider doesn't just indicate need to rebuild
 test.run(arguments='--config=force')
-test.must_not_contain(test.workpath('config.log'),"TypeError: 'NoneType' object is not callable")
-
-
+test.must_not_contain(test.workpath('config.log'), "TypeError: 'NoneType' object is not callable", mode='r')
 
 test.pass_test()
 

--- a/test/Configure/option--config.py
+++ b/test/Configure/option--config.py
@@ -122,6 +122,25 @@ test.checkLogAndStdout( ["Checking for C header file non_system_header0.h... ",
                      [((".c", CR), (_obj, NCR))]],
                     "config.log", ".sconf_temp", "SConstruct")
 
+
+# Check the combination of --config=force and Decider('MD5-timestamp')
+# On second run there was an issue where the decider would throw DeciderNeedsNode
+# exception which the configure code didn't handle.
+SConstruct_path = test.workpath('SConstruct')
+test.write(SConstruct_path, """
+env = Environment()
+env.Decider('MD5-timestamp')
+conf = Configure(env)
+conf.TryLink('int main(){return 0;}','.c')
+env = conf.Finish()
+""")
+test.run(arguments='--config=force')
+# On second run the sconsign is loaded and decider doesn't just indicate need to rebuild
+test.run(arguments='--config=force')
+test.must_not_contain(test.workpath('config.log'),"TypeError: 'NoneType' object is not callable")
+
+
+
 test.pass_test()
 
 # Local Variables:


### PR DESCRIPTION
Fix issue #3283 

    - Fix Issue #3283 - Handle using --config=force in combination with Decider('MD5-timestamp').
      3.0.2 in fix for issue #2980 added that deciders can throw DeciderNeedsNode exception.
      The Configure logic directly calls the decider when using --config=force but wasn't handling
      that exception.  This would yield minimally configure tests using TryLink() not running and
      leaving TypeError Nonetype exception in config.log


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
