### PR TITLE
Do not store build host name

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -84,7 +84,10 @@ if not developer:
 
 build_system = ARGUMENTS.get('BUILD_SYSTEM')
 if not build_system:
-    build_system = socket.gethostname().split('.')[0]
+    if os.environ.get('SOURCE_DATE_EPOCH'):
+        build_system = '_reproducible'
+    else:
+        build_system = socket.gethostname().split('.')[0]
 
 version = ARGUMENTS.get('VERSION', '')
 if not version:
@@ -159,7 +162,8 @@ command_line_variables = [
 
     ("BUILD_SYSTEM=",   "The system on which the packages were built.  " +
                         "The default is whatever hostname is returned " +
-                        "by socket.gethostname()."),
+                        "by socket.gethostname(). If SOURCE_DATE_EPOCH " +
+                        "env var is set, '_reproducible' is the default."),
 
     ("CHECKPOINT=",     "The specific checkpoint release being packaged, " +
                         "which will be appended to the VERSION string.  " +

--- a/SConstruct
+++ b/SConstruct
@@ -81,6 +81,8 @@ if not developer:
         developer = os.environ.get(variable)
         if developer:
             break
+    if os.environ.get('SOURCE_DATE_EPOCH'):
+        developer = '_reproducible'
 
 build_system = ARGUMENTS.get('BUILD_SYSTEM')
 if not build_system:
@@ -181,7 +183,9 @@ command_line_variables = [
 
     ("DEVELOPER=",      "The developer who created the packages.  " +
                         "The default is the first set environment " +
-                        "variable from the list $USERNAME, $LOGNAME, $USER."),
+                        "variable from the list $USERNAME, $LOGNAME, $USER." +
+                        "If the SOURCE_DATE_EPOCH env var is set, " +
+                        "'_reproducible' is the default."),
 
     ("REVISION=",       "The revision number of the source being built.  " +
                         "The default is the git hash returned " +

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -27,7 +27,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix syntax on is/is not cluases: should not use with a literal
 
   From Bernhard M. Wiedemann:
-    - Do not store build host name if reproducible builds are wanted
+    - Do not store build host+user name if reproducible builds are wanted
 
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -24,7 +24,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
       not using a context manager around Popen.stdout
     - Add the textfile tool to the default tool list
-    - Fix syntax on is/is not cluases: should not use with a literal
+    - Fix syntax on is/is not clauses: should not use with a literal
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -26,6 +26,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add the textfile tool to the default tool list
     - Fix syntax on is/is not cluases: should not use with a literal
 
+  From Bernhard M. Wiedemann:
+    - Do not store build host name if reproducible builds are wanted
+
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
 


### PR DESCRIPTION
* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

Do not store build host name
if reproducible builds are wanted.
See https://reproducible-builds.org/ for why this is good.

This affected scons itself, which differed in the line

```python
__buildsys__ = "..."
```