### PR TITLE
Update Job module to use thread.daemon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -53,6 +53,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Added new sconsign filenames to skip_entry_list in Scanner/Dir.py
     - Change SCons.Scanner.Base to ScannerBase. Old name kept as an alias
       but is now unused in SCons itself.
+    - Maintenance: Python thread.setDaemon is deprecated in favor of
+      directly updating daemon attribute - update SCons to do this.
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -33,6 +33,7 @@ import os
 import signal
 
 import SCons.Errors
+import SCons.Warnings
 
 # The default stack size (in kilobytes) of the threads used to execute
 # jobs in parallel.
@@ -139,7 +140,7 @@ class Jobs:
                 self.job.taskmaster.stop()
                 self.job.interrupted.set()
             else:
-                os._exit(2)
+                os._exit(2)  # pylint: disable=protected-access
 
         self.old_sigint  = signal.signal(signal.SIGINT, handler)
         self.old_sigterm = signal.signal(signal.SIGTERM, handler)
@@ -231,7 +232,7 @@ else:
 
         def __init__(self, requestQueue, resultsQueue, interrupted):
             threading.Thread.__init__(self)
-            self.setDaemon(1)
+            self.daemon = True
             self.requestQueue = requestQueue
             self.resultsQueue = resultsQueue
             self.interrupted = interrupted
@@ -389,7 +390,7 @@ else:
                         if task.needs_execute():
                             # dispatch task
                             self.tp.put(task)
-                            jobs = jobs + 1
+                            jobs += 1
                         else:
                             task.executed()
                             task.postprocess()
@@ -400,7 +401,7 @@ else:
                 # back and put the next batch of tasks on the queue.
                 while True:
                     task, ok = self.tp.get()
-                    jobs = jobs - 1
+                    jobs -= 1
 
                     if ok:
                         task.executed()


### PR DESCRIPTION
Replaces call to deprecated thread.setDaemon. No functional change.

Also added an import and a couple of pylint squashers. No functional change for these either.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
