### PR TITLE
Fix crash when a signal handler is set from outside Python

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change SCons.Scanner.Base to ScannerBase. Old name kept as an alias
       but is now unused in SCons itself.
 
+  From Brian Quistorff:
+    - Fix crash when scons is run from a python environement where a signal
+      is set from outside Python.
+
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -147,15 +147,23 @@ class Jobs:
             self.old_sighup = signal.signal(signal.SIGHUP, handler)
         except AttributeError:
             pass
+        if (self.old_sigint is None) or (self.old_sigterm is None) or \
+            (hasattr(self, "old_sighup") and self.old_sighup is None):
+            msg = "Overwritting previous signal handler which was not installed from Python. " + \
+                "Will not be able to reinstate and so will return to default handler."
+            SCons.Warnings.warn(SCons.Warnings.SConsWarning, msg)
 
     def _reset_sig_handler(self):
         """Restore the signal handlers to their previous state (before the
          call to _setup_sig_handler()."""
 
-        signal.signal(signal.SIGINT, self.old_sigint)
-        signal.signal(signal.SIGTERM, self.old_sigterm)
+        signal.signal(signal.SIGINT, self.old_sigint if self.old_sigint is not None \
+            else signal.SIG_DFL)
+        signal.signal(signal.SIGTERM, self.old_sigterm if self.old_sigterm is not None \
+            else signal.SIG_DFL)
         try:
-            signal.signal(signal.SIGHUP, self.old_sighup)
+            signal.signal(signal.SIGHUP, self.old_sighup if self.old_sighup is not None \
+                else signal.SIG_DFL)
         except AttributeError:
             pass
 

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -148,7 +148,7 @@ class Jobs:
         except AttributeError:
             pass
         if (self.old_sigint is None) or (self.old_sigterm is None) or \
-            (hasattr(self, "old_sighup") and self.old_sighup is None):
+                (hasattr(self, "old_sighup") and self.old_sighup is None):
             msg = "Overwritting previous signal handler which was not installed from Python. " + \
                 "Will not be able to reinstate and so will return to default handler."
             SCons.Warnings.warn(SCons.Warnings.SConsWarning, msg)
@@ -156,14 +156,13 @@ class Jobs:
     def _reset_sig_handler(self):
         """Restore the signal handlers to their previous state (before the
          call to _setup_sig_handler()."""
-
-        signal.signal(signal.SIGINT, self.old_sigint if self.old_sigint is not None \
-            else signal.SIG_DFL)
-        signal.signal(signal.SIGTERM, self.old_sigterm if self.old_sigterm is not None \
-            else signal.SIG_DFL)
+        sigint_to_use = self.old_sigint if self.old_sigint is not None else signal.SIG_DFL
+        sigterm_to_use = self.old_sigterm if self.old_sigterm is not None else signal.SIG_DFL
+        signal.signal(signal.SIGINT, sigint_to_use)
+        signal.signal(signal.SIGTERM, sigterm_to_use)
         try:
-            signal.signal(signal.SIGHUP, self.old_sighup if self.old_sighup is not None \
-                else signal.SIG_DFL)
+            sigterm_to_use = self.old_sighup if self.old_sighup is not None else signal.SIG_DFL
+            signal.signal(signal.SIGHUP, sigterm_to_use)
         except AttributeError:
             pass
 


### PR DESCRIPTION
If a signal handler is set from outside python (e.g., C extension) then retrieving the signal returns None ([docs](https://docs.python.org/3/library/signal.html#signal.getsignal)), but that value can't be then used to set the signal. In this case reset to default handler after we're done.

I ran into this problem running SCons from a Python environment created inside Stata (a statistical program). It could conceivably happen in other scenarios if a C extension registers a signal handler.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation

I do not know how to setup a unit test for this issue. Nor did a see an appropriate place to update the documents.