### PR TITLE
Node attributes depends and ignore should not be None because it leads to crash after calling FS.release_target_info

### DIFF
--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -3089,9 +3089,9 @@ class File(Base):
             if not len(self.depends_set):
                 self.depends_set = None
             if not len(self.ignore):
-                self.ignore = None
+                self.ignore = []
             if not len(self.depends):
-                self.depends = None
+                self.depends = []
             # Mark this node as done, we only have to release
             # the memory once...
             self.released_target_info = True


### PR DESCRIPTION
Node attributes `depends` and `ignore` should not be ``None`` because it leads to crash after calling ``FS.release_target_info`` in ``Node.get_binfo`` (iterating over ``self.depends`` and ``self.ignore`` …): 

```
binfo.bdepends = [d for d in self.depends if d not in ignore_set]
```

and  on ``Executor.get_unignored_sources``
```
key = (node,) + tuple(ignore)
```

## Contributor Checklist:

- [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
- [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
- [x] I have updated the appropriate documentation
