### PR TITLE
Make subst call a callable with sig set properly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -75,6 +75,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       problems, allowing a more helpful error to be emitted (issue #2828)
     - Maintenance: Python thread.setDaemon is deprecated in favor of
       directly updating daemon attribute - update SCons to do this.
+    - Make sure when subst'ing a callable, the callable is called with
+      the correct for_signature value, previously it would be true even
+      if doing SUBST_RAW (issue #4037)
+
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -416,6 +416,7 @@ class StringSubber:
                 return conv(substitute(l, lvars))
             return list(map(func, s))
         elif callable(s):
+
             # SCons has the unusual Null class where any __getattr__ call returns it's self, 
             # which does not work the signature module, and the Null class returns an empty
             # string if called on, so we make an exception in this condition for Null class
@@ -427,7 +428,7 @@ class StringSubber:
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,
-                     for_signature=(self.mode != SUBST_CMD))
+                     for_signature=(self.mode == SUBST_SIG))
             else:
                 # This probably indicates that it's a callable
                 # object that doesn't match our calling arguments

--- a/test/textfile/fixture/SConstruct.issue-4037
+++ b/test/textfile/fixture/SConstruct.issue-4037
@@ -1,0 +1,18 @@
+env = Environment()
+
+def generator(source, target, env, for_signature):
+    if for_signature:
+        return "sig"
+    return "val"
+
+env['GENERATOR'] = generator
+
+env.Textfile(
+    target="target",
+    source=[
+        "@generated@",
+    ],
+    SUBST_DICT={
+        '@generated@' : '$GENERATOR',
+    },
+)

--- a/test/textfile/issue-3540.py
+++ b/test/textfile/issue-3540.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 """
 Test for GH Issue 3540
 

--- a/test/textfile/issue-4037.py
+++ b/test/textfile/issue-4037.py
@@ -24,11 +24,13 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test for GH Issue 3550
+Test for GH Issue 4037
 
-You can't pass a Windows path in a value to be interpolated, 
-because SCons will try to pass it through re.sub which rejects
-certain character sequences.
+The fix for #4031 created a code path where the subst function
+used by textfile was called with SUBST_RAW, which, if the items to
+subst was a callable, caused it to be called with for_signature=True.
+This did not happen previously as the test was "!= SUBST_CMD",
+and the mode coming in was indeed SUBST_CMD.
 """
 
 import TestSCons
@@ -37,13 +39,14 @@ test = TestSCons.TestSCons()
 
 match_mode = 'r'
 
-test.file_fixture('fixture/SConstruct.issue-3550', 'SConstruct')
-test.file_fixture('fixture/substfile.in', 'substfile.in')
+test.file_fixture('fixture/SConstruct.issue-4037', 'SConstruct')
 
 test.run(arguments='.')
 
-test.must_match('substfile',
-                r'''foo_path: Z:\mongo\build\install\bin
-''', mode=match_mode)
+test.must_match(
+    'target.txt',
+    "val",
+    mode=match_mode,
+)
 
 test.pass_test()

--- a/test/textfile/textfile.py
+++ b/test/textfile/textfile.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation


### PR DESCRIPTION
If the substable element is a callable, only set `for_signature` true if the mode is `SUBST_SIG`. Previously it was set even if the mode was `SUBST_RAW`.

Fixes #4037

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
