### PR TITLE
skip test on non-linux platforms

### DIFF
--- a/test/leaky-handles.py
+++ b/test/leaky-handles.py
@@ -28,15 +28,14 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that file handles aren't leaked to child processes
 """
 
-import os
 import sys
 
 import TestSCons
 
 test = TestSCons.TestSCons()
 
-if os.name != 'posix' or sys.platform == 'darwin':
-    msg = "Skipping fork leak test on non-posix platform '%s'\n" % os.name
+if sys.platform != 'linux':
+    msg = "Skipping fork leak test on non-linux platforms\n"
     test.skip_test(msg)
 
 test.write('SConstruct', """


### PR DESCRIPTION
leaky-handles requires a `/proc/` partition which isn't present on most posix-y platforms: OpenBSD and darwin lacks a procfs, while on FreeBSD must be explicitly mounted by the user (is disabled by default.)

Furthermore, the test itself is quite fragile because depends on a behavior of the interpreter which AFAIK is not documented.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation

(I don't know if the last two point applies to this PR)