### PR TITLE
drop unnecessary soname check on OpenBSD

### DIFF
--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -57,13 +57,6 @@ obj = env.SharedObject('bar', 'foo.c')
 Default(env.Library(target='foo', source=obj))
 """)
 
-test.write('SConstructBaz', """
-env = Environment()
-env['SHLIBVERSION'] = '1.0.0'
-obj = env.SharedObject('baz', 'foo.c')
-Default(env.SharedLibrary(target='baz', source=obj))
-""")
-
 test.write('foo.c', r"""
 #include <stdio.h>
 
@@ -287,12 +280,6 @@ main(int argc, char *argv[])
 
     test.run(program = test.workpath('progbar'),
              stdout = "f4.c\nprogbar.c\n")
-
-if sys.platform.startswith('openbsd'):
-    # Make sure we don't link libraries with -Wl,-soname on OpenBSD.
-    test.run(arguments = '-f SConstructBaz')
-    for line in test.stdout().split('\n'):
-        test.fail_test(line.find('-Wl,-soname=libbaz.so') != -1)
 
 test.pass_test()
 


### PR DESCRIPTION
The changelog for the 4.1 release says that

- No longer automatically disable setting SONAME on shared libraries
  on OpenBSD.

this bit was left out.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
