### PR TITLE
fix test some test expected stderr regexp

### DIFF
--- a/test/Errors/execute-a-directory.py
+++ b/test/Errors/execute-a-directory.py
@@ -64,7 +64,7 @@ scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 cannot_execute = """\
-(sh: )*.+: cannot execute( \\[Is a directory\\])?
+(sh: )*.+: cannot execute(( -)? \\[?Is a directory\\]?)?
 scons: \\*\\*\\* \\[%s\\] Error %s
 """
 

--- a/test/Errors/non-executable-file.py
+++ b/test/Errors/non-executable-file.py
@@ -53,7 +53,7 @@ scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 cannot_execute = """\
-(sh: )*.+: cannot execute( \\[Permission denied\\])?
+(sh: )*.+: cannot execute(( -)? \\[?Permission denied\\]?)?
 scons: \\*\\*\\* \\[%s\\] Error %s
 """
 


### PR DESCRIPTION
On OpenBSD the output is

    sh: <filename>: cannot execute - Is a directory

and similarly for the non-executable file case.