### PR TITLE
DOC: Fixing typo where word "too" should read "tool" in preface.xml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,9 +9,6 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From Prabhu S. Khalsa:
-    - Fix typo in user documentation (issue #4458)
-
   From Ataf Fazledin Ahamed:
     - Use of NotImplemented instead of NotImplementedError for special methods
       of _ListVariable class
@@ -55,6 +52,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Sten Grüner:
     - Fix of the --debug=sconscript option to return exist statements when using return
       statement with stop flag enabled
+
+  From Prabhu S. Khalsa:
+    - Fix typo in user documentation (issue #4458)
 
   From Mats Wichmann:
     - Add support for Python 3.13 (as of alpha 2). So far only affects

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Prabhu S. Khalsa:
+    - Fix typo in user documentation (issue #4458)
+
   From Ataf Fazledin Ahamed:
     - Use of NotImplemented instead of NotImplementedError for special methods
       of _ListVariable class

--- a/doc/user/preface.xml
+++ b/doc/user/preface.xml
@@ -29,7 +29,7 @@ SPDX-License-Identifier: MIT
 
   Thank you for taking the time to read about &SCons;.
   &SCons; is a modern
-  software construction too - a software utility
+  software construction tool - a software utility
   for building software (or other files)
   and keeping built software up-to-date
   whenever the underlying input files change.


### PR DESCRIPTION
Added quick documentation fix where "too" should read "tool." There is no test needed for this

fixes #4458 


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
