### PR TITLE
Latex scanner missing dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Extended unittests (crudely) to test for correct/expected response
       when default setting is a boolean string.
 
+  From Keith Prussing:
+    - Fixed LaTeX SCanner to mimic LaTeX's search behavior for included files.
+
   From Mats Wichmann:
     - Clean up C and C++ FLAGS tests. Tests which use a real compiler
       are now more clearly distinguished (-live.py suffix and docstring).

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -61,6 +61,8 @@ FIXES
 - Ninja tool generate_command() fixed to call subst() with correct
   arguments in ListAction case. Unit tests added for generate_command.
 
+- Fix the SCons.Scanner.LaTeX to mimic LaTeX's search method.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -391,7 +391,6 @@ class LaTeX(ScannerBase):
 
         queue = []
         queue.extend( self.scan(node) )
-        seen = {}
 
         # This is a hand-coded DSU (decorate-sort-undecorate, or
         # Schwartzian transform) pattern.  The sort key is the raw name
@@ -407,12 +406,6 @@ class LaTeX(ScannerBase):
 
             include = queue.pop()
             inc_type, inc_subdir, inc_filename = include
-
-            try:
-                if seen[inc_filename]:
-                    continue
-            except KeyError:
-                seen[inc_filename] = True
 
             #
             # Handle multiple filenames in include[1]

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -315,7 +315,8 @@ class LaTeX(ScannerBase):
 
         for n in try_names:
             for search_path in search_paths:
-                paths = tuple([d.Dir(inc_subdir) for d in search_path])
+                paths = tuple([d.Dir(inc_subdir) for d in search_path] +
+                              list(search_path))
                 i = SCons.Node.FS.find_file(n, paths)
                 if i:
                     return i, include

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -433,7 +433,9 @@ class LaTeX(ScannerBase):
                 # recurse down
                 queue.extend(self.scan(n, inc_subdir))
 
-        return [pair[1] for pair in sorted(nodes)]
+        # Don't sort on a tuple where the second element is an object, just
+        # use the first element of the tuple which is the "sort_key" value
+        return [pair[1] for pair in sorted(nodes, key=lambda n: n[0])]
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -391,6 +391,7 @@ class LaTeX(ScannerBase):
 
         queue = []
         queue.extend( self.scan(node) )
+        seen = {}
 
         # This is a hand-coded DSU (decorate-sort-undecorate, or
         # Schwartzian transform) pattern.  The sort key is the raw name
@@ -411,6 +412,12 @@ class LaTeX(ScannerBase):
             # Handle multiple filenames in include[1]
             #
             n, i = self.find_include(include, source_dir, path_dict)
+            try:
+                if seen[str(n)]:
+                    continue
+            except KeyError:
+                seen[str(n)] = True
+
             if n is None:
                 # Do not bother with 'usepackage' warnings, as they most
                 # likely refer to system-level files

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -23,6 +23,7 @@
 
 import collections
 import os
+import sys
 import unittest
 
 import TestCmd
@@ -206,7 +207,15 @@ class LaTeXScannerTestCase5(unittest.TestCase):
          path = s.path(env)
          deps = s(env.File('test6.latex'), env, path)
          files = ['inc1.tex', 'inc2.tex', 'subdir/inc3.tex', 'subdir2/inc3.tex']
-         deps_match(self, deps, files)
+
+         # on windows the paths used to sort are all caps and use backslash
+         # due to this only on windows subdir2 < subdir\, so this is the expected order
+         files_win = ['inc1.tex', 'inc2.tex', 'subdir2/inc3.tex', 'subdir/inc3.tex']
+         
+         if sys.platform == 'win32':
+             deps_match(self, deps, files_win)
+         else:
+             deps_match(self, deps, files)
 
 if __name__ == "__main__":
     unittest.main()

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -75,6 +75,12 @@ test.write('beamerthemescons.sty',r"""
 for theme in ('color', 'font', 'inner', 'outer'):
     test.write('beamer' + theme + 'themescons.sty', "\n")
 
+test.write('test6.latex',r"""
+\include{inc1}
+\subimport{subdir}{inc3}
+\subimport{subdir2}{inc3}
+""")
+
 test.subdir('subdir')
 
 test.write('inc1.tex',"\n")
@@ -89,6 +95,10 @@ test.write('inc5.xyz', "\n")
 test.write('inc6.tex', "\n")
 test.write('inc7.png', "\n")
 test.write('incNO.tex', "\n")
+
+test.subdir('subdir2')
+
+test.write(['subdir2', 'inc3.tex'], "\\input{inc2}\n")
 
 # define some helpers:
 #   copied from CTest.py
@@ -187,6 +197,15 @@ class LaTeXScannerTestCase5(unittest.TestCase):
          deps = s(env.File('test5.latex'), env, path)
          files = ['beamer' + _ + 'themescons.sty' for _ in
                   ('color', 'font', 'inner', 'outer', '')]
+         deps_match(self, deps, files)
+
+class LaTeXScannerTestCase5(unittest.TestCase):
+     def runTest(self) -> None:
+         env = DummyEnvironment(TEXINPUTS=[test.workpath("subdir")],LATEXSUFFIXES = [".tex", ".ltx", ".latex"])
+         s = SCons.Scanner.LaTeX.LaTeXScanner()
+         path = s.path(env)
+         deps = s(env.File('test6.latex'), env, path)
+         files = ['inc1.tex', 'inc2.tex', 'subdir/inc3.tex', 'subdir2/inc3.tex']
          deps_match(self, deps, files)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the LaTeX Scanner to mimic the native behavior of LaTeX. In particular, it adds the default search path after the local subdirectory search and allows for reuse of file names conditional on them being distinct.

Closes #4728 

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
