### PR TITLE
tempfile: minor changes to handle tempfile encoding exceptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tar bz2 and xz tests should be skipped on Windows 10 and GitHub
       windows-2022. The packaging tar bz2 and xz tests should be run on
       Windows 11 and GitHub windows-2025.
+    - TEMPFILE: Move encoding the tempfile contents before creating the
+      tempfile due to possible encoding errors. Ensure the tempfile file
+      handle is closed after writing the tempfile contents. Raise a
+      TempFileEncodeError exception when the tempfile contents encoding fails
+      for known exception types.
 
   From William Deegan:
     - Fix Issue #4746. TEMPFILE's are written with utf-8 encoding, In case

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,6 +44,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   these variables and values are propagated to the user's SCons
   environment after running the MSVC batch files.
 
+- TEMPFILE: A TempFileEncodeException is raised when encoding the
+  contents of the tempfile fails due to a limited set of expected
+  exceptions (e.g., UnicodeError).
+
 FIXES
 -----
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,8 +44,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   these variables and values are propagated to the user's SCons
   environment after running the MSVC batch files.
 
-- TEMPFILE: A TempFileEncodeException is raised when encoding the
-  contents of the tempfile fails due to a limited set of expected
+- TEMPFILE: A TempFileEncodeError exception is raised when encoding
+  the contents of the tempfile fails due to a limited set of expected
   exceptions (e.g., UnicodeError).
 
 FIXES

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -60,7 +60,7 @@ import SCons.Util
 TEMPFILE_DEFAULT_ENCODING = "utf-8"
 
 
-class TempFileEncodeError(Exception):
+class TempFileEncodeError(SCons.Errors.UserError):
     pass
 
 
@@ -267,9 +267,10 @@ class TempFileMunge:
                 encoding_msg = "env['TEMPFILEENCODING']"
             else:
                 encoding_msg = "default"
-            err_msg = f"[{exc_type.__name__}] {exc_value!s}"
+            new_exc = TempFileEncodeError
+            err_msg = f"{new_exc.__name__} [{exc_type.__name__}] {exc_value!s}"
             err_msg += f"\n  {type(self).__name__} encoding: {encoding_msg} = {encoding!r}"
-            raise TempFileEncodeError(err_msg) from None
+            raise new_exc(err_msg) from None
 
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -65,7 +65,7 @@ class TempFileEncodeError(SCons.Errors.UserError):
     @classmethod
     def factory(cls, errmsg):
         errmsg = f"{cls.__name__}: {errmsg!s}"
-        return TempFileEncodeError(errmsg)
+        return cls(errmsg)
 
 
 def platform_default():

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -57,7 +57,7 @@ import SCons.Tool
 import SCons.Util
 
 
-class TempFileEncodeError(SCons.Errors.UserError):
+class TempFileEncodeError(Exception):
     pass
 
 

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -260,7 +260,7 @@ class TempFileMunge:
         encoding = env.get('TEMPFILEENCODING', TEMPFILE_DEFAULT_ENCODING)
 
         try:
-            tempfile_contents= bytes(contents, encoding=encoding)
+            tempfile_contents = bytes(contents, encoding=encoding)
         except (UnicodeError, LookupError, TypeError):
             exc_type, exc_value, exc_traceback = sys.exc_info()
             if 'TEMPFILEENCODING' in env:

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -252,6 +252,7 @@ class TempFileMunge:
         tempfile_esc_func = env.get('TEMPFILEARGESCFUNC', SCons.Subst.quote_spaces)
         args = [tempfile_esc_func(arg) for arg in cmd[1:]]
         join_char = env.get('TEMPFILEARGJOIN', ' ')
+        contents = join_char.join(args) + "\n"
 
         if 'TEMPFILEENCODING' in env:
             encoding = env['TEMPFILEENCODING']
@@ -275,7 +276,7 @@ class TempFileMunge:
             return exc_type, exc_args
 
         try:
-            tempfile_contents= bytes(join_char.join(args) + "\n", encoding=encoding)
+            tempfile_contents= bytes(contents, encoding=encoding)
         except (UnicodeError, LookupError, TypeError) as e:
             exc_type, exc_args = _encoding_exception_helper(e, encoding_isuser)
             raise exc_type(*exc_args) from e

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -60,13 +60,6 @@ import SCons.Util
 TEMPFILE_DEFAULT_ENCODING = "utf-8"
 
 
-class TempFileEncodeError(SCons.Errors.UserError):
-
-    def __init__(self, message):
-        message = f"{self.__class__.__name__}: {message!s}"
-        super().__init__(message)
-
-
 def platform_default():
     r"""Return the platform string for our execution environment.
 
@@ -270,9 +263,9 @@ class TempFileMunge:
                 encoding_msg = "env['TEMPFILEENCODING']"
             else:
                 encoding_msg = "default"
-            err_msg = f"[{exc_type.__name__}] {exc_value!s}"
+            err_msg = f"tempfile encoding error: [{exc_type.__name__}] {exc_value!s}"
             err_msg += f"\n  {type(self).__name__} encoding: {encoding_msg} = {encoding!r}"
-            raise TempFileEncodeError(err_msg)
+            raise SCons.Errors.UserError(err_msg)
 
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -146,6 +146,9 @@ class PlatformSpec:
         return self.name
 
 
+TEMPFILE_DEFAULT_ENCODING = "utf-8"
+
+
 class TempFileMunge:
     """Convert long command lines to use a temporary file.
 
@@ -246,6 +249,37 @@ class TempFileMunge:
         if cmdlist is not None:
             return cmdlist
 
+        tempfile_esc_func = env.get('TEMPFILEARGESCFUNC', SCons.Subst.quote_spaces)
+        args = [tempfile_esc_func(arg) for arg in cmd[1:]]
+        join_char = env.get('TEMPFILEARGJOIN', ' ')
+
+        if 'TEMPFILEENCODING' in env:
+            encoding = env['TEMPFILEENCODING']
+            encoding_isuser = True
+        else:
+            encoding = TEMPFILE_DEFAULT_ENCODING
+            encoding_isuser = False
+
+        def _encoding_exception_helper(exc, encoding_isuser):
+            # MUST be called from exception handler
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            encoding_msg = "env['TEMPFILEENCODING']" if encoding_isuser else "default"
+            if exc_type is UnicodeEncodeError:
+                err_msg = str(exc.reason)
+                exc_args = [exc.encoding, exc.object, exc.start, e.end]
+            else:
+                err_msg = str(exc_value)
+                exc_args = []
+            err_msg += f"\n  {type(self).__name__} encoding error ({encoding_msg}={encoding!r}):"
+            exc_args.append(err_msg)
+            return exc_type, exc_args
+
+        try:
+            tempfile_contents= bytes(join_char.join(args) + "\n", encoding=encoding)
+        except (UnicodeError, LookupError, TypeError) as e:
+            exc_type, exc_args = _encoding_exception_helper(e, encoding_isuser)
+            raise exc_type(*exc_args) from e
+
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
@@ -262,6 +296,12 @@ class TempFileMunge:
 
         # default is binary - encode the tempfile contents later
         fd, tmp = tempfile.mkstemp(suffix, dir=tempfile_dir)
+
+        try:
+            os.write(fd, tempfile_contents)
+        finally:
+            os.close(fd)
+
         native_tmp = SCons.Util.get_native_path(tmp)
 
         # arrange for cleanup on exit:
@@ -280,13 +320,6 @@ class TempFileMunge:
             prefix = env.subst('$TEMPFILEPREFIX')
         else:
             prefix = "@"
-
-        tempfile_esc_func = env.get('TEMPFILEARGESCFUNC', SCons.Subst.quote_spaces)
-        args = [tempfile_esc_func(arg) for arg in cmd[1:]]
-        join_char = env.get('TEMPFILEARGJOIN', ' ')
-        encoding = env.get('TEMPFILEENCODING', 'utf-8')
-        os.write(fd, bytes(join_char.join(args) + "\n", encoding=encoding))
-        os.close(fd)
 
         # XXX Using the SCons.Action.print_actions value directly
         # like this is bogus, but expedient.  This class should

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -62,10 +62,9 @@ TEMPFILE_DEFAULT_ENCODING = "utf-8"
 
 class TempFileEncodeError(SCons.Errors.UserError):
 
-    @classmethod
-    def factory(cls, errmsg):
-        errmsg = f"{cls.__name__}: {errmsg!s}"
-        return cls(errmsg)
+    def __init__(self, message):
+        message = f"{self.__class__.__name__}: {message!s}"
+        super().__init__(message)
 
 
 def platform_default():
@@ -273,7 +272,7 @@ class TempFileMunge:
                 encoding_msg = "default"
             err_msg = f"[{exc_type.__name__}] {exc_value!s}"
             err_msg += f"\n  {type(self).__name__} encoding: {encoding_msg} = {encoding!r}"
-            raise TempFileEncodeError.factory(err_msg)
+            raise TempFileEncodeError(err_msg)
 
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -61,7 +61,11 @@ TEMPFILE_DEFAULT_ENCODING = "utf-8"
 
 
 class TempFileEncodeError(SCons.Errors.UserError):
-    pass
+
+    @classmethod
+    def factory(cls, errmsg):
+        errmsg = f"{cls.__name__}: {errmsg!s}"
+        return TempFileEncodeError(errmsg)
 
 
 def platform_default():
@@ -267,10 +271,9 @@ class TempFileMunge:
                 encoding_msg = "env['TEMPFILEENCODING']"
             else:
                 encoding_msg = "default"
-            new_exc = TempFileEncodeError
-            err_msg = f"{new_exc.__name__} [{exc_type.__name__}] {exc_value!s}"
+            err_msg = f"[{exc_type.__name__}] {exc_value!s}"
             err_msg += f"\n  {type(self).__name__} encoding: {encoding_msg} = {encoding!r}"
-            raise new_exc(err_msg) from None
+            raise TempFileEncodeError.factory(err_msg)
 
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -57,6 +57,9 @@ import SCons.Tool
 import SCons.Util
 
 
+TEMPFILE_DEFAULT_ENCODING = "utf-8"
+
+
 class TempFileEncodeError(Exception):
     pass
 
@@ -148,9 +151,6 @@ class PlatformSpec:
 
     def __str__(self) -> str:
         return self.name
-
-
-TEMPFILE_DEFAULT_ENCODING = "utf-8"
 
 
 class TempFileMunge:
@@ -262,12 +262,12 @@ class TempFileMunge:
         try:
             tempfile_contents = bytes(contents, encoding=encoding)
         except (UnicodeError, LookupError, TypeError):
-            exc_type, exc_value, exc_traceback = sys.exc_info()
+            exc_type, exc_value, _ = sys.exc_info()
             if 'TEMPFILEENCODING' in env:
                 encoding_msg = "env['TEMPFILEENCODING']"
             else:
                 encoding_msg = "default"
-            err_msg = f"[{exc_type.__name__}] {str(exc_value)}"
+            err_msg = f"[{exc_type.__name__}] {exc_value!s}"
             err_msg += f"\n  {type(self).__name__} encoding: {encoding_msg} = {encoding!r}"
             raise TempFileEncodeError(err_msg) from None
 

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -74,8 +74,8 @@ scons\:.*
 """
 
 expected_fail = """\
-TempFileEncodeError\\s*\: \[{exception}\] .+
-  TempFileMunge encoding\: env\['TEMPFILEENCODING'\] = {encoding!r}
+TempFileEncodeError\\s*\: TempFileEncodeError \[{exception}\] .+
+  TempFileMunge encoding\: env\['TEMPFILEENCODINGx'\] = {encoding!r}
 scons\:.*
 """
 
@@ -85,7 +85,7 @@ SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
 
 expected_fail_default = """\
 SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
-TempFileEncodeError\\s*\: \[{exception}\] .+
+TempFileEncodeError\\s*\: TempFileEncodeError \[{exception}\] .+
   TempFileMunge encoding\: default = {encoding!r}
 scons\:.*
 """

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -75,7 +75,7 @@ scons\:.*
 
 expected_fail = """\
 TempFileEncodeError\\s*\: TempFileEncodeError \[{exception}\] .+
-  TempFileMunge encoding\: env\['TEMPFILEENCODINGx'\] = {encoding!r}
+  TempFileMunge encoding\: env\['TEMPFILEENCODING'\] = {encoding!r}
 scons\:.*
 """
 

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Verify that setting the $TEMPFILEENCODING variable will be used for
+encoding the file contents when writing the generated tempfile used
+for long command lines.
+"""
+
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+SCONSTRUCT_TEMPLATE="""
+import sys
+import SCons.Platform
+
+command = 'xyz ./test€/file.c'
+encoding = {encoding!r}
+
+tempfileencoding = {tempfileencoding}
+defaultencoding = {defaultencoding}
+
+DefaultEnvironment()
+
+if defaultencoding:
+    SCons.Platform.TEMPFILE_DEFAULT_ENCODING = encoding
+    print("SCons.Platform.TEMPFILE_DEFAULT_ENCODING = {encoding!r}")
+
+env = Environment(
+    tools=[],
+    MAXLINELENGTH=2,
+)
+
+if tempfileencoding:
+    env['TEMPFILEENCODING'] = encoding
+
+tfm = SCons.Platform.TempFileMunge(command)
+
+try:
+    tfm(None, None, env, 0)
+except Exception:
+    exc_type, exc_value, _ = sys.exc_info()
+    print(f"{{exc_type.__name__}} : {{str(exc_value)}}")
+"""
+
+expected_pass = """\
+Using tempfile \\S+ for command line:
+xyz \\S+
+scons\:.*
+"""
+
+expected_fail = """\
+TempFileEncodeError\\s*\: \[{exception}\] .+
+  TempFileMunge encoding\: env\['TEMPFILEENCODING'\] = {encoding!r}
+scons\:.*
+"""
+
+expected_pass_default = """\
+SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
+""" + expected_pass
+
+expected_fail_default = """\
+SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
+TempFileEncodeError\\s*\: \[{exception}\] .+
+  TempFileMunge encoding\: default = {encoding!r}
+scons\:.*
+"""
+
+for test_encoding, test_tempfileencoding, test_defaultencoding, test_expected in [
+
+    # expected pass
+    ('',          False, False, expected_pass),
+    ('utf-8',      True, False, expected_pass),
+    ('utf-8-sig',  True, False, expected_pass),
+    ('utf-16',     True, False, expected_pass),
+    ('utf-16',    False,  True, expected_pass_default.format(encoding='utf-16')),
+
+    # expected fail
+    ('ascii',    True, False, expected_fail.format(exception='UnicodeEncodeError', encoding='ascii')),
+    ('missing',  True, False, expected_fail.format(exception='LookupError', encoding='missing')),
+    ('',         True, False, expected_fail.format(exception='LookupError', encoding='')),
+    (None,       True, False, expected_fail.format(exception='TypeError', encoding=None)),
+    ('ascii',   False,  True, expected_fail_default.format(exception='UnicodeEncodeError', encoding='ascii')),
+
+]:
+
+    sconstruct = SCONSTRUCT_TEMPLATE.format(
+        encoding = test_encoding,
+        tempfileencoding = test_tempfileencoding,
+        defaultencoding = test_defaultencoding,
+    )
+    
+    test.write('SConstruct', sconstruct)
+
+    test.run(
+        arguments='-n -Q .',
+        stdout=test_expected,
+        match=TestSCons.match_re,
+    )
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -35,7 +35,6 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 SCONSTRUCT_TEMPLATE="""
-import sys
 import SCons.Platform
 
 command = 'xyz ./test€/file.c'
@@ -62,9 +61,8 @@ tfm = SCons.Platform.TempFileMunge(command)
 
 try:
     tfm(None, None, env, 0)
-except Exception:
-    exc_type, exc_value, _ = sys.exc_info()
-    print(f"{{str(exc_value)}}")
+except SCons.Platform.TempFileEncodeError as e:
+    print(str(e))
 """
 
 expected_pass = """\

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -64,7 +64,7 @@ try:
     tfm(None, None, env, 0)
 except Exception:
     exc_type, exc_value, _ = sys.exc_info()
-    print(f"{{exc_type.__name__}} : {{str(exc_value)}}")
+    print(f"{{str(exc_value)}}")
 """
 
 expected_pass = """\
@@ -74,7 +74,7 @@ scons\:.*
 """
 
 expected_fail = """\
-TempFileEncodeError\\s*\: TempFileEncodeError \[{exception}\] .+
+TempFileEncodeError: \[{exception}\] .+
   TempFileMunge encoding\: env\['TEMPFILEENCODING'\] = {encoding!r}
 scons\:.*
 """
@@ -85,7 +85,7 @@ SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
 
 expected_fail_default = """\
 SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
-TempFileEncodeError\\s*\: TempFileEncodeError \[{exception}\] .+
+TempFileEncodeError: \[{exception}\] .+
   TempFileMunge encoding\: default = {encoding!r}
 scons\:.*
 """

--- a/test/TEMPFILE/fixture/SConstruct-tempfile-encoding
+++ b/test/TEMPFILE/fixture/SConstruct-tempfile-encoding
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+import SCons.Errors
+import SCons.Script
+
+SCons.Script.AddOption(
+    '--encoding',
+    dest='encoding',
+    type='string',
+    nargs=1,
+    default='',
+    action='store',
+    help='tempfile encoding string',
+)
+
+SCons.Script.AddOption(
+    '--set-tempfile-encoding',
+    dest='tempfileencoding',
+    default=False,
+    action='store_const',
+    const=True,
+    help='set tempfile encoding: false (default) or true',
+)
+
+SCons.Script.AddOption(
+    '--set-default-encoding',
+    dest='defaultencoding',
+    default=False,
+    action='store_const',
+    const=True,
+    help='set default encoding: false (default) or true',
+)
+
+encoding = SCons.Script.GetOption('encoding').lower()
+if encoding in ('none',):
+    encoding = None
+
+tempfileencoding = SCons.Script.GetOption('tempfileencoding')
+defaultencoding = SCons.Script.GetOption('defaultencoding')
+
+command = 'xyz ./test€/file.c'
+
+DefaultEnvironment(tools=[])
+
+if defaultencoding:
+    SCons.Platform.TEMPFILE_DEFAULT_ENCODING = encoding
+    print(f"SCons.Platform.TEMPFILE_DEFAULT_ENCODING = {encoding!r}")
+
+env = Environment(
+    tools=[],
+    MAXLINELENGTH=2,
+)
+
+if tempfileencoding:
+    env['TEMPFILEENCODING'] = encoding
+
+tfm = SCons.Platform.TempFileMunge(command)
+
+try:
+    tfm(None, None, env, 0)
+except SCons.Errors.UserError as e:
+    print(str(e))


### PR DESCRIPTION
Provide explicit error messages for tempfile encoding failures and reduce the likelihood of an open tempfile file handle at exit.

Based on discussions #4749, #4746, and #4752.

Changes to `TempFileMunge` (`SCons\.Platform\.__init__.py`):
* Move encoding the tempfile contents before creating the tempfile due to possible encoding errors.
* Ensure the tempfile file handle is closed after writing the tempfile contents.
* Raise a `TempFileEncodeError` exception when the tempfile contents encoding fails for known exception types.

Example `TempFileEncodeError` exceptions:

* `UnicodeEncodeError` (user-defined encoding):
  ```
  scons: *** [src\main.obj] TempFileEncodeError : [UnicodeEncodeError] 'charmap' codec can't encode characters in position 85-86: character maps to <undefined>
    TempFileMunge encoding: env['TEMPFILEENCODING'] = 'cp1252'
  Traceback (most recent call last):
  ...
  SCons.Platform.TempFileEncodeError: [UnicodeEncodeError] 'charmap' codec can't encode characters in position 85-86: character maps to <undefined>
    TempFileMunge encoding: env['TEMPFILEENCODING'] = 'cp1252'
  ```

* `LookupError` (user-defined encoding):
  ```
  scons: *** [src\main.obj] TempFileEncodeError : [LookupError] unknown encoding: notinstalled
    TempFileMunge encoding: env['TEMPFILEENCODING'] = 'notinstalled'
  Traceback (most recent call last):
  ...
  SCons.Platform.TempFileEncodeError: [LookupError] unknown encoding: notinstalled
    TempFileMunge encoding: env['TEMPFILEENCODING'] = 'notinstalled'
  ```

* `TypeError` (user-defined encoding):
  ```
  scons: *** [src\main.obj] TempFileEncodeError : [TypeError] bytes() argument 'encoding' must be str, not None
    TempFileMunge encoding: env['TEMPFILEENCODING'] = None
  Traceback (most recent call last):
  ...
  SCons.Platform.TempFileEncodeError: [TypeError] bytes() argument 'encoding' must be str, not None
    TempFileMunge encoding: env['TEMPFILEENCODING'] = None
  ```

* `UnicodeError` (user-modified default encoding):
  ```
  scons: *** [src\main.obj] TempFileEncodeError : [UnicodeEncodeError] 'charmap' codec can't encode characters in position 85-86: character maps to <undefined>
    TempFileMunge encoding: default = 'cp1252'
  Traceback (most recent call last):
  ...
  SCons.Platform.TempFileEncodeError: [UnicodeEncodeError] 'charmap' codec can't encode characters in position 85-86: character maps to <undefined>
    TempFileMunge encoding: default = 'cp1252'
  ```
  
The `TempFileEncodeError` exception text contains:
* The exception name (`TempFileEncodeError`) is an indication what failed.
* The underlying exception name (`[UnicodeEncodeError]`) and reason is an indication of why it failed.
* The `TempFileMunge` line indicates if a user-defined encoding value was defined or the default encoding value was used and/or modified.

If nothing else, this should make it easier to decipher what us happening should the exception text be posted in the mailing list or in an issue.

Not addressed:
* The tempfile removal invocation (i.e., `os.remove(file)`) in the `atexit` handler has not been changed.  Moving the tempfile encoding before the tempfile is opened and closing the tempfile on write errors should reduce the likelihood of errors upon removal.  However, anti-virus software could always be a problem.

Feature complete: no additional changes planned.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
