### PR TITLE
Minor test-releated tweak for Python selection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -162,6 +162,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve the wording of Configure methods.
     - Add unit test cases for AppendUnique, PrependUnique - verify behavior
       if existing value already contained more than one of added value.
+    - Tweak runtest.py and test framework to more reliably get the requested
+      Python binary (for odd Windows setups + Python launcher)
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -83,6 +83,9 @@ FIXES
   as the default path for temporary files includes the username. Setting
   (existing) TEMPFILEDIR may also help in this case.
 
+- Tweak runtest.py and test framework to more reliably get the requested
+  Python binary (for odd Windows setups + Python launcher)
+
 IMPROVEMENTS
 ------------
 

--- a/runtest.py
+++ b/runtest.py
@@ -1,7 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+#
+# SPDX-License-Identifier: MIT
 #
 # Copyright The SCons Foundation
-#
+
 """runtest - wrapper script for running SCons tests
 
 The SCons test suite consists of:

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1724,7 +1724,15 @@ SConscript(sconscript)
 
         Returns a path to a Python executable suitable for testing on
         this platform and its associated include path, library path and
-        library name.
+        library name. ``runtest.py`` sets an environment variable with the
+        desired Python path, so if we're started from there, use that.
+
+        This exists because of SWIG, which may need to build things against
+        the Python header and library.  The approach is a bit of a large
+        hammer: we run a script like we would a test, and capture the results,
+        rather than querying the running Python. This supports the test
+        runner's ``-P`` option to specify an alternate Python, otherwise
+        we wouldn't need to be this complex.
 
         If the Python executable or Python header (if required)
         is not found, the test is skipped.
@@ -1732,7 +1740,7 @@ SConscript(sconscript)
         Returns:
             tuple: path to python, include path, library path, library name
         """
-        python = os.environ.get('python_executable', self.where_is('python'))
+        python = os.environ.get('python_executable', sys.executable)
         if not python:
             self.skip_test(
                 'Can not find installed "python", skipping test.\n', from_fw=True


### PR DESCRIPTION
Use a different shebang line for `runtest.py` and align the framework's interpreter details routine with elsewhere to more reliably get "the Python we want".  Windows systems with Python launcher sometimes got an odd result.

No impacts to SCons itself or to docs.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
