### PR TITLE
Add tests to FSTests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -173,6 +173,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Python binary (for odd Windows setups + Python launcher)
     - Improve the wording of AppendENVPath and PrependENVPath in manpage.
     - Add more unit tests to internal AppendPath, PrependPath functions.
+    - Add unit tests to show .filebase method strips only the last suffix if
+      several apparent suffixes are present, and .suffix returns the last.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -3842,6 +3842,7 @@ class SpecialAttrTestCase(unittest.TestCase):
         fs = SCons.Node.FS.FS(test.workpath('work'))
 
         f = fs.Entry('foo/bar/baz.blat').get_subst_proxy()
+        f2 = fs.Entry('foo/bar/baz.blat.qux').get_subst_proxy()
 
         s = str(f.dir)
         assert s == os.path.normpath('foo/bar'), s
@@ -3866,12 +3867,16 @@ class SpecialAttrTestCase(unittest.TestCase):
         assert f.filebase.is_literal(), f.filebase
         for_sig = f.filebase.for_signature()
         assert for_sig == 'baz.blat_filebase', for_sig
+        s = str(f2.filebase)
+        assert s == 'baz.blat', s
 
         s = str(f.suffix)
         assert s == '.blat', s
         assert f.suffix.is_literal(), f.suffix
         for_sig = f.suffix.for_signature()
         assert for_sig == 'baz.blat_suffix', for_sig
+        s = str(f2.suffix)
+        assert s == '.qux', s
 
         s = str(f.get_abspath())
         assert s == test.workpath('work', 'foo', 'bar', 'baz.blat'), s


### PR DESCRIPTION
Confirm that for a filename with multiple dots, the .filebase method strips only the last suffix, and the .suffix method returns only the last.

Test-only change, so no doc impacts.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
