### PR TITLE
Missing builders produce more targeted message

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -175,6 +175,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add more unit tests to internal AppendPath, PrependPath functions.
     - Add unit tests to show .filebase method strips only the last suffix if
       several apparent suffixes are present, and .suffix returns the last.
+    - Improve the error message when an environment method is called which
+      does not exist in that environment. Mostly this is intended to be a
+      bit more helpful in the case of a builder which did not instantiate.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -105,8 +105,12 @@ IMPROVEMENTS
   in 3.3; now looks for the official approach first. This in an internal
   detail, the API is unchanged.
 
-- Add internal routines to maniplutate publicly visible argument and
+- Add internal routines to manipulate publicly visible argument and
   target lists. These interfaces are not part of the public API.
+
+- Improve the error message when an environment method is called which
+  does not exist in that environment. Mostly this is intended to be a
+  bit more helpful in the case of a builder which did not instantiate.
 
 PACKAGING
 ---------

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1295,6 +1295,24 @@ class Base(SubstitutionEnvironment):
         if parse_flags:
             self.MergeFlags(parse_flags)
 
+    def __getattr__(self, name):
+        """Handle missing attribute in an environment.
+
+        Assume this is a builder that's not instantiated, becasue that has
+        been a common failure mode. Could also  be a typo. Emit a
+        message about this to try to help. We can't get too clever,
+        other parts of SCons depend on seeing the :exc:`AttributeError` that
+        triggers this call, so all we do is produce our own message.
+
+        .. versioniadded:: NEXT_RELEASE
+        """
+        raise AttributeError(
+            f"Builder or other environment method {name!r} not found.\n"
+            "Check spelling, check external program exists in env['ENV']['PATH'],\n"
+            "and check that a suitable tool is being loaded"
+       ) from None
+
+
     #######################################################################
     # Utility methods that are primarily for internal use by SCons.
     # These begin with lower-case letters.

--- a/test/Removed/BuildDir/BuildDir.py
+++ b/test/Removed/BuildDir/BuildDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,36 +23,36 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 """
 Verify that the  BuildDir function and method no longer work.
 """
 
 import TestSCons
-
 _exe = TestSCons._exe
-
 test = TestSCons.TestSCons(match=TestSCons.match_exact)
 
 test.subdir('src')
 
 test.file_fixture('SConstruct.global', 'SConstruct')
-expect = """\
+expect = f"""\
 NameError: name 'BuildDir' is not defined:
-  File "{}", line 2:
+  File "{test.workpath('SConstruct')}", line 2:
     BuildDir('build', 'src')
 """.format(test.workpath('SConstruct'))
 test.run(arguments='-Q -s', status=2, stderr=expect)
 
 test.file_fixture('SConstruct.method', 'SConstruct')
-expect = """\
-AttributeError: 'SConsEnvironment' object has no attribute 'BuildDir':
-  File "{}", line 3:
+expect = f"""\
+AttributeError: Builder or other environment method 'BuildDir' not found.
+Check spelling, check external program exists in env['ENV']['PATH'],
+and check that a suitable tool is being loaded:
+  File "{test.workpath('SConstruct')}", line 3:
     env.BuildDir('build', 'src')
-""".format(test.workpath('SConstruct'))
-test.run(arguments='-Q -s', status=2, stderr=expect)
+"""
 
+# test.run(arguments='-Q -s', status=2, stderr=expect)
+test.run(arguments='-Q -s', status=2, stderr=None)
+test.must_contain_all(test.stderr(), expect)
 
 test.pass_test()
 

--- a/test/Removed/Copy-Method/Copy-Method.py
+++ b/test/Removed/Copy-Method/Copy-Method.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that env.Copy() fails as expected since its removal
@@ -33,12 +32,15 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 test.file_fixture('SConstruct.method', 'SConstruct')
-expect = """\
-AttributeError: 'SConsEnvironment' object has no attribute 'Copy':
-  File "{}", line 3:
+expect = f"""\
+AttributeError: Builder or other environment method 'Copy' not found.
+Check spelling, check external program exists in env['ENV']['PATH'],
+and check that a suitable tool is being loaded:
+  File "{test.workpath('SConstruct')}", line 3:
     env.Copy()
-""".format(test.workpath('SConstruct'))
-test.run(arguments='-Q -s', status=2, stderr=expect, match=TestSCons.match_exact)
+"""
+test.run(arguments='-Q -s', status=2, stderr=None)
+test.must_contain_all(test.stderr(), expect)
 
 test.pass_test()
 

--- a/test/Removed/SourceCode/SourceCode.py
+++ b/test/Removed/SourceCode/SourceCode.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,8 +23,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 """
 Test the removed SourceCode() method errors out if used.
 """
@@ -30,24 +30,27 @@ Test the removed SourceCode() method errors out if used.
 import TestSCons
 
 test = TestSCons.TestSCons(match=TestSCons.match_exact)
-
 test.subdir('src')
 
 test.file_fixture('SConstruct.global', 'SConstruct')
-expect = """\
+expect = f"""\
 NameError: name 'SourceCode' is not defined:
-  File "{}", line 2:
+  File "{test.workpath('SConstruct')}", line 2:
     SourceCode('no_source.c', None)
-""".format(test.workpath('SConstruct'))
-test.run(arguments='-Q -s', status=2, stderr=expect)
+"""
+test.run(arguments='-Q -s', status=2, stderr=None)
+test.must_contain_all(test.stderr(), expect)
 
 test.file_fixture('SConstruct.method', 'SConstruct')
-expect = """\
-AttributeError: 'SConsEnvironment' object has no attribute 'SourceCode':
-  File "{}", line 3:
+expect = f"""\
+AttributeError: Builder or other environment method 'SourceCode' not found.
+Check spelling, check external program exists in env['ENV']['PATH'],
+and check that a suitable tool is being loaded:
+  File "{test.workpath('SConstruct')}", line 3:
     env.SourceCode('no_source.c', None)
-""".format(test.workpath('SConstruct'))
-test.run(arguments='-Q -s', status=2, stderr=expect)
+"""
+test.run(arguments='-Q -s', status=2, stderr=None)
+test.must_contain_all(test.stderr(), expect)
 
 test.pass_test()
 


### PR DESCRIPTION
Simply traps the `AttributeError` by adding a `__getattr__` to `SCons.Environment.Base` and prints a message that gives some ideas. Behavior does not change, and there's no cost - we don't reach this code unless we're already handling an exception for a missing attribute.

An initial thought was to use methods named in `SCons.Script.GlobalDefaultBuilders` to trigger the more detailed message, as a warning (off by default, but can be enabled).  After letting it sink in for a while, that didn't seem to be any real benefit to that extra step, nor for hiding the message in a warning. So now consider this as a "better error message" and nothing more.

Another intial thought was to reclassify this as a `UserError` - you have either misspelled a method, or it's not in the execution environment path, or the tool never ran to set it up, all of which are the developer's problem. But enough code depends on this being an `AttributeError` specifically that several things broke - would have been a lot more work than a "quick fix".

Doesn't do anything for the case of missing "global function" type builders, they have their own processing logic which raises a `NameError`.

This is in response to multiple issue reports on confusing errors (#863 and #1671 are open, #1437, #1442, #1873, #1895, #1007 closed as dupes - at least), but does not really "fix" them, that appears to require some rearchitecting of how the whole tools+builders+environment-methods scheme works to gather early information so you can really tell what is unavailable that was expected to be available.

Three tests for removed features that expected a specific message on attempt to access that feature were reworked as a result.

There is no API-level effect, so no documentation changes.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
