### PR TITLE
Switch TestSCons from profile to cProfile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,9 +12,12 @@ NOTE: Since SCons 4.9.0, Python 3.7.0 or above is required.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From John Doe:
+    - Whatever John Doe did.
 
-        - Whatever John Doe did.
+  From Mats Wichmann:
+    - Switch test framework from using profile to cProfile. profile
+      generates deprecation warnings starting with Python 3.15.
 
 
 RELEASE 4.10.0 -  Thu, 02 Oct 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,9 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- Switch test framework from using profile to cProfile. profile
+  generates deprecation warnings starting with Python 3.15.
+
 FIXES
 -----
 

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -137,13 +137,13 @@ Total command execution time: 44.456789 seconds
 profile_py = """\
 %(body)s
 
-import profile
+import cProfile
 
-try: dispatch = profile.Profile.dispatch
+try: dispatch = cProfile.Profile.dispatch
 except AttributeError: pass
-else: dispatch['c_exception'] = profile.Profile.trace_dispatch_return
+else: dispatch['c_exception'] = cProfile.Profile.trace_dispatch_return
 
-prof = profile.Profile()
+prof = cProfile.Profile()
 prof.runcall(%(call)s)
 prof.dump_stats(r'%(profile_name)s')
 """

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -139,10 +139,6 @@ profile_py = """\
 
 import cProfile
 
-try: dispatch = cProfile.Profile.dispatch
-except AttributeError: pass
-else: dispatch['c_exception'] = cProfile.Profile.trace_dispatch_return
-
 prof = cProfile.Profile()
 prof.runcall(%(call)s)
 prof.dump_stats(r'%(profile_name)s')


### PR DESCRIPTION
Tests were failing on Python 3.15alpha due to a deprecation warning for the profile module.

This is a test-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
