### PR TITLE
manpage: make clickable links for Get/SetOption

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Switch test framework from using profile to cProfile. profile
       generates deprecation warnings starting with Python 3.15.
     - Improve documentation of builder methods and builder objects.
+    - Make links clickable in the SetOption and GetOption manpage entries.
 
 
 RELEASE 4.10.0 -  Thu, 02 Oct 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -58,6 +58,8 @@ DOCUMENTATION
 
 - Improve documentation of builder methods and builder objects.
 
+- Make links clickable in the SetOption and GetOption manpage entries.
+
 DEVELOPMENT
 -----------
 

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -345,9 +345,9 @@ atexit.register(print_build_failures)
 </arguments>
 <summary>
 <para>
-Query the value of settable options which may have been set
-on the command line, via option defaults,
-or by using the &f-link-SetOption; function.
+Query the value of settable option <parameter>name</parameter>,
+which may have been set on the command line, via option defaults,
+or using the &f-link-SetOption; function.
 The value of the option is returned in a type matching how the
 option was declared - see the documentation of the
 corresponding command line option for information about each specific
@@ -369,7 +369,7 @@ processed prior to the &f-GetOption; call in the &SConscript; files.
 <thead>
 <row>
   <entry align="left">Query name</entry>
-  <entry align="left">Command-line options</entry>
+  <entry align="left">Command-line argument</entry>
   <entry align="left">Notes</entry>
 </row>
 </thead>
@@ -377,46 +377,61 @@ processed prior to the &f-GetOption; call in the &SConscript; files.
 <tbody>
 <row>
   <entry><varname>cache_debug</varname></entry>
-  <entry><option>--cache-debug</option></entry>
+  <entry>
+    <link linkend="opt-cache-debug"><option>--cache-debug</option></link>
+  </entry>
+
 </row>
 <row>
   <entry><varname>cache_disable</varname></entry>
   <entry>
+    <link linkend="opt-cache-disable">
       <option>--cache-disable</option>,
       <option>--no-cache</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>cache_force</varname></entry>
   <entry>
+    <link linkend="opt-cache-force">
       <option>--cache-force</option>,
       <option>--cache-populate</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>cache_readonly</varname></entry>
-  <entry><option>--cache-readonly</option></entry>
+  <entry>
+    <link linkend="opt-cache-readonly"><option>--cache-readonly</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>cache_show</varname></entry>
-  <entry><option>--cache-show</option></entry>
+  <entry>
+    <link linkend="opt-cache-show"><option>--cache-show</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>clean</varname></entry>
   <entry>
+    <link linkend="opt-clean">
       <option>-c</option>,
       <option>--clean</option>,
       <option>--remove</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>climb_up</varname></entry>
   <entry>
-      <option>-D</option>
-      <option>-U</option>
-      <option>-u</option>
-      <option>--up</option>
+    <link linkend="opt-up">
+      <option>-D</option>,
+      <option>-U</option>,
+      <option>-u</option>,
+      <option>--up</option>,
       <option>--search_up</option>
+    </link>
   </entry>
 </row>
 <row>
@@ -425,162 +440,244 @@ processed prior to the &f-GetOption; call in the &SConscript; files.
 </row>
 <row>
   <entry><varname>debug</varname></entry>
-  <entry><option>--debug</option></entry>
+  <entry><link linkend="opt-debug"><option>--debug</option></link></entry>
 </row>
 <row>
   <entry><varname>directory</varname></entry>
-  <entry><option>-C</option>, <option>--directory</option></entry>
+  <entry>
+    <link linkend="opt-directory">
+      <option>-C</option>,
+      <option>--directory</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>diskcheck</varname></entry>
-  <entry><option>--diskcheck</option></entry>
+  <entry><link linkend="opt-diskcheck"><option>--diskcheck</option></link></entry>
 </row>
 <row>
   <entry><varname>duplicate</varname></entry>
-  <entry><option>--duplicate</option></entry>
+  <entry><link linkend="opt-duplicate"><option>--duplicate</option></link></entry>
 </row>
 <row>
   <entry><varname>enable_virtualenv</varname></entry>
-  <entry><option>--enable-virtualenv</option></entry>
+  <entry>
+    <link linkend="opt-enable-virtualenv"><option>--enable-virtualenv</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>experimental</varname></entry>
-  <entry><option>--experimental</option></entry>
-  <entry><emphasis>since 4.2</emphasis></entry>
+  <entry>
+    <link linkend="opt-experimental"><option>--experimental</option></link>
+  </entry>
+  <entry><emphasis>Since 4.2</emphasis>.</entry>
 </row>
 <row>
   <entry><varname>file</varname></entry>
   <entry>
+    <link linkend="opt-sconstruct">
       <option>-f</option>,
       <option>--file</option>,
       <option>--makefile</option>,
       <option>--sconstruct</option>
+    </link>
+  </entry>
+</row>
+<row>
+  <entry><varname>hash_chunksize</varname></entry>
+  <entry>
+    <link linkend="opt-hash-chunksize"><option>--hash-chunksize</option></link>
+  </entry>
+  <entry>
+    Replaces <option>md5_chunksize</option>. <emphasis>Since 4.2</emphasis>
   </entry>
 </row>
 <row>
   <entry><varname>hash_format</varname></entry>
-  <entry><option>--hash-format</option></entry>
-  <entry><emphasis>since 4.2</emphasis></entry>
+  <entry><link linkend="opt-hash-format"><option>--hash-format</option></link></entry>
+  <entry><emphasis>Since 4.2</emphasis></entry>
 </row>
 <row>
   <entry><varname>help</varname></entry>
-  <entry><option>-h</option>, <option>--help</option></entry>
+  <entry>
+      <link linkend="opt-help">
+        <option>-h</option>, <option>--help</option>
+      </link>
+  </entry>
 </row>
 <row>
   <entry><varname>ignore_errors</varname></entry>
-  <entry><option>-i</option>, <option>--ignore-errors</option></entry>
+  <entry>
+    <link linkend="opt-ignore-errors">
+      <option>-i</option>,
+      <option>--ignore-errors</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>ignore_virtualenv</varname></entry>
-  <entry><option>--ignore-virtualenv</option></entry>
+  <entry>
+    <link linkend="opt-ignore-virtualenv"><option>--ignore-virtualenv</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>implicit_cache</varname></entry>
-  <entry><option>--implicit-cache</option></entry>
+  <entry>
+    <link linkend="opt-implicit-cache"><option>--implicit-cache</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>implicit_deps_changed</varname></entry>
-  <entry><option>--implicit-deps-changed</option></entry>
+  <entry>
+    <link linkend="opt-implicit-deps-changed"><option>--implicit-deps-changed</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>implicit_deps_unchanged</varname></entry>
-  <entry><option>--implicit-deps-unchanged</option></entry>
+  <entry>
+    <link linkend="opt-implicit-deps-unchanged">
+      <option>--implicit-deps-unchanged</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>include_dir</varname></entry>
-  <entry><option>-I</option>, <option>--include-dir</option></entry>
+  <entry>
+    <link linkend="opt-include-dir">
+      <option>-I</option>,
+      <option>--include-dir</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>install_sandbox</varname></entry>
-  <entry><option>--install-sandbox</option></entry>
+  <entry>
+    <link linkend="opt-install-sandbox"><option>--install-sandbox</option></link>
+  </entry>
   <entry>Available only if the &t-link-install; tool has been called</entry>
 </row>
 <row>
   <entry><varname>keep_going</varname></entry>
-  <entry><option>-k</option>, <option>--keep-going</option></entry>
+  <entry>
+    <link linkend="opt-keep-going">
+      <option>-k</option>,
+      <option>--keep-going</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>max_drift</varname></entry>
-  <entry><option>--max-drift</option></entry>
+  <entry><link linkend="opt-max-drift"><option>--max-drift</option></link></entry>
 </row>
 <row>
   <entry><varname>md5_chunksize</varname></entry>
   <entry>
-      <option>--hash-chunksize</option>,
-      <option>--md5-chunksize</option>
+    <link linkend="opt-hash-chunksize"><option>--hash-chunksize</option></link>
   </entry>
-  <entry><emphasis><option>--hash-chunksize</option> since 4.2</emphasis></entry>
+  <entry>
+    Replaced by <option>hash_chunksize</option>.
+    <emphasis>Deprecated since 4.2</emphasis>
+  </entry>
 </row>
 <row>
   <entry><varname>no_exec</varname></entry>
   <entry>
+    <link linkend="opt-no-exec">
       <option>-n</option>,
       <option>--no-exec</option>,
       <option>--just-print</option>,
       <option>--dry-run</option>,
       <option>--recon</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>no_progress</varname></entry>
-  <entry><option>-Q</option></entry>
+  <entry><link linkend="opt-Q"><option>-Q</option></link></entry>
 </row>
 <row>
   <entry><varname>num_jobs</varname></entry>
-  <entry><option>-j</option>, <option>--jobs</option></entry>
+  <entry>
+    <link linkend="opt-jobs"><option>-j</option>, <option>--jobs</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>package_type</varname></entry>
-  <entry><option>--package-type</option></entry>
+  <entry>
+    <link linkend="opt-package-type"><option>--package-type</option></link>
+  </entry>
   <entry>Available only if the &t-link-packaging; tool has been called</entry>
 </row>
 <row>
   <entry><varname>profile_file</varname></entry>
-  <entry><option>--profile</option></entry>
+  <entry><link linkend="opt-profile"><option>--profile</option></link></entry>
 </row>
 <row>
   <entry><varname>question</varname></entry>
-  <entry><option>-q</option>, <option>--question</option></entry>
+  <entry>
+    <link linkend="opt-question">
+      <option>-q</option>,
+      <option>--question</option>
+    </link>
+  </entry>
 </row>
 <row>
   <entry><varname>random</varname></entry>
-  <entry><option>--random</option></entry>
+  <entry>
+    <link linkend="opt-random"><option>--random</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>repository</varname></entry>
   <entry>
+    <link linkend="opt-repository">
       <option>-Y</option>,
       <option>--repository</option>,
       <option>--srcdir</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>silent</varname></entry>
   <entry>
+    <link linkend="opt-silent">
       <option>-s</option>,
       <option>--silent</option>,
       <option>--quiet</option>
+    </link>
   </entry>
 </row>
 <row>
   <entry><varname>site_dir</varname></entry>
-  <entry><option>--site-dir</option>, <option>--no-site-dir</option></entry>
+  <entry>
+    <link linkend="opt-site-dir"><option>--site-dir</option></link>,
+    <link linkend="opt-no-site-dir"><option>--no-site-dir</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>stack_size</varname></entry>
-  <entry><option>--stack-size</option></entry>
+  <entry>
+    <link linkend="opt-stack-size"><option>--stack-size</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>taskmastertrace_file</varname></entry>
-  <entry><option>--taskmastertrace</option></entry>
+  <entry>
+    <link linkend="opt-taskmastertrace"><option>--taskmastertrace</option></link>
+  </entry>
 </row>
 <row>
   <entry><varname>tree_printers</varname></entry>
-  <entry><option>--tree</option></entry>
+  <entry><link linkend="opt-tree"><option>--tree</option></link></entry>
 </row>
 <row>
   <entry><varname>warn</varname></entry>
-  <entry><option>--warn</option>, <option>--warning</option></entry>
+  <entry>
+    <link linkend="opt-warn">
+      <option>--warn</option>,
+      <option>--warning</option>
+    </link>
+  </entry>
 </row>
 
 </tbody>
@@ -782,24 +879,22 @@ in many situations when defining target names that are not directly built.
 </arguments>
 <summary>
 <para>
-Sets &scons; option variable <parameter>name</parameter>
+Set option variable <parameter>name</parameter>
 to <parameter>value</parameter>.
-These options are all also settable via
-command-line options but the variable name
-may differ from the command-line option name -
-see the table for correspondences.
-A value set via command-line option will take
-precedence over one set with &f-SetOption;, which
-allows setting a project default in the scripts and
-temporarily overriding it via command line.
-&f-SetOption; calls can also be placed in the
+Settable  options have corresponding command-line
+arguments, which can be used for one-time overrides,
+as a value set via command-line option will take
+precedence over one set with &f-SetOption;.
+The table shows the correspondence between the
+option name and the command-line argument(s).
+&f-SetOption; calls can also be placed in a
 <filename>site_init.py</filename> file.
 </para>
 
 <para>
-See the documentation in the manpage for the
-corresponding command line option for information about each specific option.
-The <parameter>value</parameter> parameter is mandatory,
+The behavior of the options is described in the
+manpage entry for the command-line version.
+The <parameter>value</parameter> parameter is mandatory;
 for option values which are boolean in nature
 (that is, the command line option does not take an argument)
 use a <parameter>value</parameter>
@@ -821,7 +916,7 @@ added via an &f-link-AddOption; call,
 &f-SetOption; is available only after the
 &f-AddOption; call has completed successfully,
 and only if that call included the
-<parameter>settable=True</parameter> argument.
+<parameter>settable=True</parameter> keyword argument.
 </para>
 
 <para>
@@ -836,7 +931,7 @@ The settable variables with their associated command-line options are:
 <thead>
 <row>
   <entry align="left">Settable name</entry>
-  <entry align="left">Command-line options</entry>
+  <entry align="left">Command-line argument</entry>
   <entry align="left">Notes</entry>
 </row>
 </thead>
@@ -845,95 +940,134 @@ The settable variables with their associated command-line options are:
 <row>
   <entry><varname>clean</varname></entry>
   <entry>
-    <option>-c</option>,
-    <option>--clean</option>,
-    <option>--remove</option>
+    <link linkend="opt-clean">
+      <option>-c</option>,
+      <option>--clean</option>,
+      <option>--remove</option>
+    </link>
   </entry>
 </row>
 
 <row>
   <entry><varname>diskcheck</varname></entry>
-  <entry><option>--diskcheck</option></entry>
+  <entry>
+    <link linkend="opt-diskcheck"><option>--diskcheck</option></link>
+  </entry>
 </row>
 
 <row>
   <entry><varname>duplicate</varname></entry>
-  <entry><option>--duplicate</option></entry>
+  <entry>
+    <link linkend="opt-duplicate"><option>--duplicate</option></link>
+  </entry>
 </row>
 
 <row>
   <entry><varname>experimental</varname></entry>
-  <entry><option>--experimental</option></entry>
-  <entry><emphasis>since 4.2</emphasis></entry>
+  <entry>
+    <link linkend="opt-experimental"><option>--experimental</option></link>
+  </entry>
+  <entry><emphasis>Since 4.2</emphasis>.</entry>
 </row>
 
 <row>
   <entry><varname>hash_chunksize</varname></entry>
-  <entry><option>--hash-chunksize</option></entry>
   <entry>
-    Actually sets <varname>md5_chunksize</varname>.
-    <emphasis>since 4.2</emphasis>
+    <link linkend="opt-hash-chunksize"><option>--hash-chunksize</option></link>
+  </entry>
+  <entry>
+    Replaces <option>md5_chunksize</option>. <emphasis>Since 4.2</emphasis>
   </entry>
 </row>
 
 <row>
   <entry><varname>hash_format</varname></entry>
-  <entry><option>--hash-format</option></entry>
-  <entry><emphasis>since 4.2</emphasis></entry>
+  <entry>
+    <link linkend="opt-hash-format"><option>--hash-format</option></link>
+  </entry>
+  <entry><emphasis>Since 4.2</emphasis></entry>
 </row>
 
 <row>
   <entry><varname>help</varname></entry>
-  <entry><option>-h</option>, <option>--help</option></entry>
+  <entry>
+    <link linkend="opt-H"><option>-h</option>, <option>--help</option></link>
+  </entry>
 </row>
+
+<!-- XXX   <varlistentry id="opt-ignore-errors"> ?? -->
 
 <row>
   <entry><varname>implicit_cache</varname></entry>
-  <entry><option>--implicit-cache</option></entry>
+  <entry>
+    <link linkend="opt-implicit-cache"><option>--implicit-cache</option></link>
+  </entry>
 </row>
 
 <row>
   <entry><varname>implicit_deps_changed</varname></entry>
-  <entry><option>--implicit-deps-changed</option></entry>
+  <entry>
+    <link linkend="opt-implicit-deps-changed">
+      <option>--implicit-deps-changed</option>
+    </link>
+  </entry>
   <entry>
     Also sets <varname>implicit_cache</varname>.
-    <emphasis>(settable since 4.2)</emphasis>
+    <emphasis>Settable since 4.2</emphasis>
   </entry>
 </row>
 
 <row>
   <entry><varname>implicit_deps_unchanged</varname></entry>
-  <entry><option>--implicit-deps-unchanged</option></entry>
+  <entry>
+    <link linkend="opt-implicit-deps-unchanged">
+      <option>--implicit-deps-unchanged</option>
+    </link>
+  </entry>
   <entry>
     Also sets <varname>implicit_cache</varname>.
-    <emphasis>(settable since 4.2)</emphasis>
+    <emphasis>Settable since 4.2</emphasis>
+  </entry>
+</row>
+
+<!-- XXX id="opt-keep-going" ?? -->
+
+<row>
+  <entry><varname>max_drift</varname></entry>
+  <entry>
+    <link linkend="opt-max-drift"><option>--max-drift</option></link>
   </entry>
 </row>
 
 <row>
-  <entry><varname>max_drift</varname></entry>
-  <entry><option>--max-drift</option></entry>
-</row>
-
-<row>
   <entry><varname>md5_chunksize</varname></entry>
-  <entry><option>--md5-chunksize</option></entry>
+  <entry>
+    <link linkend="opt-hash-chunksize"><option>--hash-chunksize</option></link>
+  </entry>
+  <entry>
+    Synonym for <option>hash_chunksize</option>.
+    <emphasis>Deprecated since 4.2</emphasis>
+  </entry>
 </row>
 
 <row>
   <entry><varname>no_exec</varname></entry>
   <entry>
-    <option>-n</option>,
-    <option>--no-exec</option>,
-    <option>--just-print</option>,
-    <option>--dry-run</option>,
-    <option>--recon</option>
+    <link linkend="opt-no-exec">
+      <option>-n</option>,
+      <option>--no-exec</option>,
+      <option>--just-print</option>,
+      <option>--dry-run</option>,
+      <option>--recon</option>
+    </link>
   </entry>
 </row>
 
 <row>
   <entry><varname>no_progress</varname></entry>
-  <entry><option>-Q</option></entry>
+  <entry>
+    <link linkend="opt-Q"><option>-Q</option></link>
+  </entry>
   <entry>See
     <footnote>
       <para>If <varname>no_progress</varname> is set via &f-SetOption;
@@ -950,31 +1084,37 @@ The settable variables with their associated command-line options are:
 
 <row>
   <entry><varname>num_jobs</varname></entry>
-  <entry><option>-j</option>, <option>--jobs</option></entry>
+  <entry>
+    <link linkend="opt-jobs"><option>-j</option>, <option>--jobs</option></link>
+  </entry>
 </row>
 
 <row>
   <entry><varname>random</varname></entry>
-  <entry><option>--random</option></entry>
+  <entry><link linkend="opt-random"><option>--random</option></link></entry>
 </row>
 
 <row>
   <entry><varname>silent</varname></entry>
   <entry>
-    <option>-s</option>,
-    <option>--silent</option>,
-    <option>--quiet</option>
+    <link linkend="opt-silent">
+      <option>-s</option>,
+      <option>--silent</option>,
+      <option>--quiet</option>
+    </link>
   </entry>
 </row>
 
 <row>
   <entry><varname>stack_size</varname></entry>
-  <entry><option>--stack-size</option></entry>
+  <entry>
+    <link linkend="opt-stack-size"><option>--stack-size</option></link>
+  </entry>
 </row>
 
 <row>
   <entry><varname>warn</varname></entry>
-  <entry><option>--warn</option></entry>
+  <entry><link linkend="opt-warn"><option>--warn</option></link></entry>
 </row>
 
 </tbody>
@@ -989,7 +1129,6 @@ Example:
 SetOption('max_drift', 0)
 </example_commands>
 </summary>
-
 
 </scons_function>
 


### PR DESCRIPTION
Both functions have equivalence tables between option names they can use and the corresponding command-line options.  The cli option names are now clickable to be able to jump to the actual descriptions (there are no option behavior descriptions in `GetOption` or `SetOption`).

A little bit of wording tweak as well, limited to these two functions.

This is a doc-only change.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
