### PR TITLE
Use "in" and "not in" instead of ".find()"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - In the SequenceTypes tuple used for dynamic type checks, include
       the dict contents views, exclude the dictionary view itself as it
       is not an interable sequence type.
+    - Internal: where the find method on a string was used to determine
+      if a substring is present, use the more readable "in" and "not in".
 
 
 RELEASE 4.10.0 -  Thu, 02 Oct 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -52,6 +52,9 @@ IMPROVEMENTS
   documentation:  performance improvements (describe the circumstances
   under which they would be observed), or major code cleanups
 
+- Internal: where the find method on a string was used to determine
+  if a substring is present, use the more readable "in" and "not in".
+
 PACKAGING
 ---------
 

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -312,7 +312,7 @@ def test_positional_args(pos_callback, cmd, **kw):
         except SCons.Errors.UserError as e:
             s = str(e)
             m = 'Invalid command display variable'
-            assert s.find(m) != -1, 'Unexpected string:  %s' % s
+            assert m in s, f'Unexpected string: {s}'
         else:
             raise Exception("did not catch expected UserError")
 
@@ -540,7 +540,7 @@ class _ActionActionTestCase(unittest.TestCase):
         except SCons.Errors.UserError as e:
             s = str(e)
             m = 'Cannot have both strfunction and cmdstr args to Action()'
-            assert s.find(m) != -1, 'Unexpected string:  %s' % s
+            assert m in s, f'Unexpected string: {s}'
         else:
             raise Exception("did not catch expected UserError")
 

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -74,15 +74,15 @@ def platform_default():
     if osname == 'posix':
         if sys.platform == 'cygwin':
             return 'cygwin'
-        elif sys.platform.find('irix') != -1:
+        elif 'irix' in sys.platform:
             return 'irix'
-        elif sys.platform.find('sunos') != -1:
+        elif 'sunos' in sys.platform:
             return 'sunos'
-        elif sys.platform.find('hp-ux') != -1:
+        elif 'hp-ux' in sys.platform:
             return 'hpux'
-        elif sys.platform.find('aix') != -1:
+        elif 'aix' in sys.platform:
             return 'aix'
-        elif sys.platform.find('darwin') != -1:
+        elif 'darwin' in sys.platform:
             return 'darwin'
         else:
             return 'posix'

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -136,10 +136,10 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
     stderrRedirected = False
     for arg in args:
         # are there more possibilities to redirect stdout ?
-        if arg.find(">", 0, 1) != -1 or arg.find("1>", 0, 2) != -1:
+        if arg.startswith(">")or arg.startswith("1>"):
             stdoutRedirected = True
         # are there more possibilities to redirect stderr ?
-        if arg.find("2>", 0, 2) != -1:
+        if arg.startswith("2>"):
             stderrRedirected = True
 
     # redirect output of non-redirected streams to our tempfiles

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -144,7 +144,7 @@ class Progressor:
             self.func = obj
         elif SCons.Util.is_List(obj):
             self.func = self.spinner
-        elif obj.find(self.target_string) != -1:
+        elif self.target_string in obj:
             self.func = self.replace_string
         else:
             self.func = self.string
@@ -644,7 +644,7 @@ def find_deepest_user_frame(tb):
     # of SCons:
     for frame in tb:
         filename = frame[0]
-        if filename.find(os.sep+'SCons'+os.sep) == -1:
+        if f'{os.sep}SCons{os.sep}' not in filename:
             return frame
     return tb[0]
 

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -561,8 +561,8 @@ class ListSubber(UserList):
                 self.close_strip('$)')
             else:
                 key = s[1:]
-                if key[0] == '{' or key.find('.') >= 0:
-                    if key[0] == '{':
+                if key.startswith('{') or '.' in key:
+                    if key.startswith('{'):
                         key = key[1:-1]
 
                 # Store for error messages if we fail to expand the
@@ -962,7 +962,7 @@ def scons_subst_once(strSubst, env, key):
 
     We do this with some straightforward, brute-force code here...
     """
-    if isinstance(strSubst, str) and strSubst.find('$') < 0:
+    if isinstance(strSubst, str) and '$' not in strSubst:
         return strSubst
 
     matchlist = ['$' + key, '${' + key + '}']

--- a/SCons/Tool/hpcxx.py
+++ b/SCons/Tool/hpcxx.py
@@ -1,15 +1,6 @@
-"""SCons.Tool.hpc++
-
-Tool-specific initialization for c++ on HP/UX.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,9 +20,15 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""SCons.Tool.hpc++
+
+Tool-specific initialization for c++ on HP/UX.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+"""
 
 import os.path
 
@@ -59,7 +56,7 @@ for dir in dirs:
         acc = cc
         break
 
-        
+
 def generate(env) -> None:
     """Add Builders and construction variables for g++ to an Environment."""
     cplusplus.generate(env)
@@ -70,7 +67,7 @@ def generate(env) -> None:
         # determine version of aCC
         with os.popen(acc + ' -V 2>&1') as p:
             line = p.readline().rstrip()
-        if line.find('aCC: HP ANSI C++') == 0:
+        if line.startswith('aCC: HP ANSI C++'):
             env['CXXVERSION'] = line.split()[-1]
 
         if env['PLATFORM'] == 'cygwin':

--- a/SCons/Tool/intelc.py
+++ b/SCons/Tool/intelc.py
@@ -569,7 +569,7 @@ def generate(env, version=None, abi=None, topdir=None, verbose: int=0):
         for ld in [envlicdir, reglicdir]:
             # If the string contains an '@', then assume it's a network
             # license (port@system) and good by definition.
-            if ld and (ld.find('@') != -1 or os.path.exists(ld)):
+            if ld and ('@' in ld or os.path.exists(ld)):
                 licdir = ld
                 break
         if not licdir:

--- a/SCons/Tool/midl.py
+++ b/SCons/Tool/midl.py
@@ -52,10 +52,10 @@ def midl_emitter(target, source, env):
 
     midlcom = env['MIDLCOM']
 
-    if midlcom.find('/proxy') != -1:
+    if '/proxy' in midlcom:
         proxy = base + '_p.c'
         targets.append(proxy)
-    if midlcom.find('/dlldata') != -1:
+    if '/dlldata' in midlcom:
         dlldata = base + '_data.c'
         targets.append(dlldata)
 

--- a/SCons/Tool/msvsTests.py
+++ b/SCons/Tool/msvsTests.py
@@ -464,7 +464,7 @@ class RegNode:
         return rv
 
     def key(self,key,sep: str = '\\'):
-        if key.find(sep) != -1:
+        if sep in key:
             keyname, subkeys = key.split(sep,1)
         else:
             keyname = key
@@ -479,7 +479,7 @@ class RegNode:
             raise SCons.Util.RegError
 
     def addKey(self,name,sep: str = '\\'):
-        if name.find(sep) != -1:
+        if sep in name:
             keyname, subkeys = name.split(sep, 1)
         else:
             keyname = name

--- a/SCons/Tool/tex.py
+++ b/SCons/Tool/tex.py
@@ -337,7 +337,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                 if os.path.isfile(target_aux):
                     with open(target_aux) as f:
                         content = f.read()
-                    if content.find("bibdata") != -1:
+                    if 'bibdata' in content:
                         if Verbose:
                             print("Need to run bibtex on ",auxfilename)
                         bibfile = env.fs.File(SCons.Util.splitext(target_aux)[0])
@@ -361,7 +361,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                 if os.path.isfile(target_bcf):
                     with open(target_bcf) as f:
                         content = f.read()
-                    if content.find("bibdata") != -1:
+                    if 'bibdata' in content:
                         if Verbose:
                             print("Need to run biber on ",bcffilename)
                         bibfile = env.fs.File(SCons.Util.splitext(target_bcf)[0])

--- a/test/AS/as-live.py
+++ b/test/AS/as-live.py
@@ -39,7 +39,8 @@ test = TestSCons.TestSCons()
 if not test.detect('AS', 'as'):
     test.skip_test("as not found; skipping test\n")
 
-x86 = (sys.platform == 'win32' or sys.platform.find('linux') != -1)
+# this is an odd check... linux runs on non-x86 hardware
+x86 = (sys.platform == 'win32' or 'linux' in sys.platform)
 if not x86:
     test.skip_test("skipping as test on non-x86 platform '%s'\n" % sys.platform)
 

--- a/test/AS/nasm.py
+++ b/test/AS/nasm.py
@@ -41,7 +41,7 @@ nasm = test.where_is('nasm')
 if not nasm:
     test.skip_test('nasm not found; skipping test\n')
 
-if sys.platform.find('linux') == -1:
+if 'linux' not in sys.platform:
     test.skip_test("skipping test on non-Linux platform '%s'\n" % sys.platform)
 
 try:
@@ -69,7 +69,7 @@ else:
 nasm_format = 'elf'
 format_map = {}
 for k, v in format_map.items():
-    if sys.platform.find(k) != -1:
+    if k in sys.platform:
         nasm_format = v
         break
 

--- a/test/Builder/errors.py
+++ b/test/Builder/errors.py
@@ -40,11 +40,11 @@ DefaultEnvironment(tools=[])
 def buildop(env, source, target):
     with open(target[0], 'wb') as outf, open(source[0], 'r') as infp:
         for line in inpf.readlines():
-            if line.find(str(target[0])) == -1:
+            if target[0] not in line:
                 outf.write(line)
 b1 = Builder(action=buildop, src_suffix='.a', suffix='.b')
 %s
-env=Environment(tools=[], BUILDERS={'b1':b1, 'b2':b2})
+env = Environment(tools=[], BUILDERS={'b1':b1, 'b2':b2})
 foo_b = env.b1(source='foo.a')
 env.b2(source=foo_b)
 """

--- a/test/CC/SHCCFLAGS-live.py
+++ b/test/CC/SHCCFLAGS-live.py
@@ -42,7 +42,7 @@ barflags = e['SHCCFLAGS'] + ' -DBAR'
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\

--- a/test/CC/SHCFLAGS-live.py
+++ b/test/CC/SHCFLAGS-live.py
@@ -42,7 +42,7 @@ barflags = e['SHCFLAGS'] + ' -DBAR'
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\

--- a/test/CPPPATH/match-dir.py
+++ b/test/CPPPATH/match-dir.py
@@ -35,7 +35,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 # TODO(sgk):  get this to work everywhere by using fake compilers
-if sys.platform.find('sunos') != -1:
+if 'sunos' in sys.platform:
     msg = 'SunOS C compiler does not handle this case; skipping test.\n'
     test.skip_test(msg)
 

--- a/test/CXX/CXXFLAGS-live.py
+++ b/test/CXX/CXXFLAGS-live.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 e = test.Environment()

--- a/test/CXX/SHCCFLAGS-live.py
+++ b/test/CXX/SHCCFLAGS-live.py
@@ -42,7 +42,7 @@ barflags = e['SHCCFLAGS'] + ' -DBAR'
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\

--- a/test/CXX/SHCXXFLAGS-live.py
+++ b/test/CXX/SHCXXFLAGS-live.py
@@ -42,7 +42,7 @@ barflags = e['SHCXXFLAGS'] + ' -DBAR'
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\

--- a/test/Errors/nonexistent-executable.py
+++ b/test/Errors/nonexistent-executable.py
@@ -61,7 +61,7 @@ if os.name == 'nt':
         konnte_nicht_gefunden_werden % ('f1', 1),
         unspecified % 'f1'
     ]
-elif sys.platform.find('sunos') != -1:
+elif 'sunos' in sys.platform:
     errs = [
         not_found_space % ('f1', 1),
     ]

--- a/test/LINK/VersionedLib-VariantDir.py
+++ b/test/LINK/VersionedLib-VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensure that SharedLibrary builder with SHLIBVERSION set works with VariantDir.
@@ -40,8 +39,6 @@ test = TestSCons.TestSCons()
 env = SCons.Defaults.DefaultEnvironment()
 platform = SCons.Platform.platform_default()
 tool_list = SCons.Platform.DefaultToolList(platform, env)
-
-
 
 test.subdir(['src'])
 test.subdir(['src','lib'])
@@ -65,7 +62,8 @@ int main(void)
 }
 """)
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 variant = { 'variant_dir' : 'build',
             'src_dir'     : 'src',
@@ -96,7 +94,7 @@ if platform == 'cygwin' or platform == 'win32':
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = test.workpath('build/lib')
-if sys.platform.find('irix') != -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = test.workpath('build/lib')
 
 test.run(program = test.workpath('build/bin/main'))

--- a/test/LINK/VersionedLib-j2.py
+++ b/test/LINK/VersionedLib-j2.py
@@ -55,7 +55,8 @@ int foo();
 int main(void) { return foo(); }
 """)
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 env.AppendUnique(LIBPATH = ['.'])
 env.Program('main.c', LIBS = ['foo'])
@@ -77,7 +78,7 @@ if platform == 'cygwin':
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = test.workpath('.')
-if sys.platform.find('irix') != -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = test.workpath('.')
 
 test.run(program = test.workpath('main'))

--- a/test/LINK/VersionedLib-subdir.py
+++ b/test/LINK/VersionedLib-subdir.py
@@ -70,7 +70,8 @@ elif 'cyglink' in tool_list:
 else:
     subdir = 'blah.so.0.1.2.blah'
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 env.AppendUnique(LIBPATH = [ '%s' ])
 env.SharedLibrary('%s/foo', 'foo.c', SHLIBVERSION = '0.1.2')
@@ -88,7 +89,7 @@ if platform == 'cygwin' or platform == 'win32':
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = subdir
-if sys.platform.find('irix') != -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = subdir
 
 test.run(program = test.workpath('main'))

--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -198,7 +198,7 @@ test.run(arguments = '.',
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') != -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.run(program = test.workpath('prog'),
@@ -211,7 +211,7 @@ if sys.platform == 'cygwin':
     test.must_not_exist('foo3.dll.a')
 
 
-if sys.platform == 'win32' or sys.platform.find('irix') != -1:
+if sys.platform == 'win32' or 'irix' in sys.platform:
     test.run(arguments='-f SConstructFoo')
 else:
     expect = r"scons: \*\*\* \[.*\] Source file: foo\..* is static and is not compatible with shared target: .*"

--- a/test/LoadableModule.py
+++ b/test/LoadableModule.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
@@ -47,7 +46,8 @@ dlopen_line = {
 }
 platforms_with_dlopen = list(dlopen_line.keys())
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 # dlopenprog tries to dynamically load foo1 at runtime using dlopen().
 env.LoadableModule(target = 'foo1', source = 'f1.c')
@@ -103,7 +103,7 @@ test.run(arguments = '.',
          match=TestSCons.match_re_dotall)
 
 # TODO: Add new Intel-based Macs?  Why are we only picking on Macs?
-#if sys.platform.find('darwin') != -1:
+#if 'darwin' in sys.platform:
 #    test.run(program='/usr/bin/file',
 #             arguments = "foo1",
 #             match = TestCmd.match_re,
@@ -114,7 +114,7 @@ if sys.platform in platforms_with_dlopen:
     os.environ['LD_LIBRARY_PATH'] = test.workpath()
     test.run(program = test.workpath('dlopenprog'),
              stdout = "f1.c\ndlopenprog.c\n")
-                 
+
 
 
 test.pass_test()

--- a/test/NodeOps.py
+++ b/test/NodeOps.py
@@ -42,7 +42,7 @@ from TestSCons import _exe, lib_, _lib, _obj, dll_, _dll
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
-if sys.platform.find('irix') > -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test = TestSCons.TestSCons()

--- a/test/QT/qt3/QTFLAGS.py
+++ b/test/QT/qt3/QTFLAGS.py
@@ -152,7 +152,7 @@ test.must_exist(
 
 def _flagTest(test,fileToContentsStart):
     for f,c in fileToContentsStart.items():
-        if test.read(test.workpath('work1', f), mode='r').find(c) != 0:
+        if not test.read(test.workpath('work1', f), mode='r').startswith(c):
             return 1
     return 0
 
@@ -172,6 +172,7 @@ test.fail_test(
 test.write(['work2', 'SConstruct'], """
 import os.path
 
+DefaultEnvironment(tools=[])
 env1 = Environment(
     tools=['qt3'],
     QT3DIR=r'%(QT3DIR)s',

--- a/test/QT/qt3/copied-env.py
+++ b/test/QT/qt3/copied-env.py
@@ -38,10 +38,10 @@ test.Qt_create_SConstruct('SConstruct', qt_tool='qt3')
 test.write('SConscript', """\
 Import("env")
 env.Append(CPPDEFINES = ['FOOBAZ'])
-                                                                                
+
 copy = env.Clone()
 copy.Append(CPPDEFINES = ['MYLIB_IMPL'])
-                                                                                
+
 copy.SharedLibrary(
    target = 'MyLib',
    source = ['MyFile.cpp','MyForm.ui']
@@ -65,9 +65,9 @@ void aaa(void)
 
 test.run()
 
-moc_MyForm = [x for x in test.stdout().split('\n') if x.find('moc_MyForm') != -1]
+moc_MyForm = [x for x in test.stdout().split('\n') if 'moc_MyForm' in x]
 
-MYLIB_IMPL = [x for x in moc_MyForm if x.find('MYLIB_IMPL') != -1]
+MYLIB_IMPL = [x for x in moc_MyForm if 'MYLIB_IMPL' in x]
 
 if not MYLIB_IMPL:
     print("Did not find MYLIB_IMPL on moc_MyForm compilation line:")

--- a/test/QT/qt3/source-from-ui.py
+++ b/test/QT/qt3/source-from-ui.py
@@ -126,7 +126,7 @@ test.must_not_exist(test.workpath(cpp))
 test.must_not_exist(test.workpath(h))
 
 cppContents = test.read(test.workpath('build', cpp), mode='r')
-test.fail_test(cppContents.find('#include "aaa.ui.h"') == -1)
+test.fail_test('#include "aaa.ui.h"' not in cppContents)
 
 test.run(
     arguments="variant_dir=1 chdir=1 "

--- a/test/Removed/BuildDir/Old/BuildDir.py
+++ b/test/Removed/BuildDir/Old/BuildDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the deprecated BuildDir() function and method still
@@ -196,7 +196,7 @@ def filter_tempnam(err):
     if not err:
         return ''
     msg = "warning: tempnam() possibly used unsafely"
-    return '\n'.join([l for l in err.splitlines() if l.find(msg) == -1])
+    return '\n'.join([l for l in err.splitlines() if msg not in l])
 
 test.run(chdir='work1', arguments = '. ../build', stderr=None)
 

--- a/test/Repository/SharedLibrary.py
+++ b/test/Repository/SharedLibrary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can create a local shared library containing shared
@@ -44,6 +43,7 @@ opts = '-Y ' + test.workpath('repository')
 
 #
 test.write(['repository', 'SConstruct'], """\
+DefaultEnvironment(tools=[])
 env = Environment()
 f1 = env.SharedObject('f1.c')
 f2 = env.SharedObject('f2.c')
@@ -114,7 +114,7 @@ if os.name == 'posix':
         os.environ['DYLD_LIBRARY_PATH'] = test.workpath('work')
     else:
         os.environ['LD_LIBRARY_PATH'] = test.workpath('work')
-if sys.platform.find('irix') != -1:
+if 'irix' in sys.platform:
     os.environ['LD_LIBRARYN32_PATH'] = test.workpath('work')
 
 test.run(program = test.workpath('work', 'prog'),

--- a/test/SideEffect/parallel.py
+++ b/test/SideEffect/parallel.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that targets with the same SideEffect are not built in parallel
@@ -65,6 +64,7 @@ os.rmdir(lockdir)
 
 test.write('SConstruct', """\
 Build = Builder(action=r'%(_python_)s build.py $SOURCE $TARGET')
+DefaultEnvironment(tools=[])
 env = Environment(BUILDERS={'Build':Build})
 env.Build('h1.out', 'h1.in')
 env.Build('g2.out', 'g2.in')
@@ -91,14 +91,14 @@ stdout = test.stdout()
 
 
 build_lines =  [
-    'build.py h1.in h1.out', 
-    'build.py g2.in g2.out', 
-    'build.py f3.in f3.out', 
+    'build.py h1.in h1.out',
+    'build.py g2.in g2.out',
+    'build.py f3.in f3.out',
 ]
 
 missing = []
 for line in build_lines:
-    if stdout.find(line) == -1:
+    if line not in stdout:
         missing.append(line)
 
 if missing:
@@ -119,7 +119,7 @@ log_lines = [
 
 missing = []
 for line in log_lines:
-    if log.find(line) == -1:
+    if line not in log:
         missing.append(line)
 
 if missing:

--- a/test/TEX/TEX.py
+++ b/test/TEX/TEX.py
@@ -60,6 +60,7 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(TEX = r'%(_python_)s mytex.py', tools=['tex'])
 env.DVI(target = 'test.dvi', source = 'test.tex')
 """ % locals())
@@ -171,13 +172,13 @@ Run \texttt{latex}, then \texttt{bibtex}, then \texttt{latex} twice again \cite{
     test.run(stderr = None)
     output_lines = test.stdout().split('\n')
 
-    reruns = [x for x in output_lines if x.find('latex -interaction=nonstopmode -recorder rerun.tex') != -1]
+    reruns = [x for x in output_lines if 'latex -interaction=nonstopmode -recorder rerun.tex' in x]
     if len(reruns) != 2:
         print("Expected 2 latex calls, got %s:" % len(reruns))
         print('\n'.join(reruns))
         test.fail_test()
 
-    bibtex = [x for x in output_lines if x.find('bibtex bibtex-test') != -1]
+    bibtex = [x for x in output_lines if 'bibtex bibtex-test' in x]
     if len(bibtex) != 1:
         print("Expected 1 bibtex call, got %s:" % len(bibtex))
         print('\n'.join(bibtex))

--- a/test/VariantDir/VariantDir.py
+++ b/test/VariantDir/VariantDir.py
@@ -236,7 +236,7 @@ def blank_output(err):
         return 1
     stderrlines = [l for l in err.split('\n') if l]
     msg = "warning: tempnam() possibly used unsafely"
-    stderrlines = [l for l in stderrlines if l.find(msg) == -1]
+    stderrlines = [l for l in stderrlines if msg not in l]
     return len(stderrlines) == 0
 
 test.run(chdir='work1', arguments = '. ../build', stderr=None)

--- a/test/option/md5-chunksize.py
+++ b/test/option/md5-chunksize.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -88,7 +87,7 @@ test.pass_test()
 #
 test2 = TestSCons.TestSCons()
 
-if sys.platform.find('linux') == -1:
+if 'linux' not in sys.platform:
     test2.skip_test("skipping test on non-Linux platform '%s'\n" % sys.platform)
 
 dd = test2.where_is('dd')

--- a/test/option/option_profile.py
+++ b/test/option/option_profile.py
@@ -95,7 +95,7 @@ test.must_contain_all_lines(test.stdout(), expect)
 
 expect = 'Memory before reading SConscript files'
 lines = test.stdout().split('\n')
-memory_lines = [l for l in lines if l.find(expect) != -1]
+memory_lines = [l for l in lines if expect in l]
 
 test.fail_test(len(memory_lines) != 1)
 

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -491,7 +491,7 @@ sys.exit(0)
         assert status == 1, status
         expect1 = "Regular expression error in '^a.*(e$': missing )"
         expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
-        assert stderr.find(expect1) != -1 or stderr.find(expect2) != -1, repr(stderr)
+        assert expect1 in stderr or expect2 in stderr, repr(stderr)
 
     def test_simple_diff_static_method(self) -> None:
         """Test calling the TestCmd.TestCmd.simple_diff() static method"""
@@ -1261,9 +1261,7 @@ sys.exit(0)
             assert status == 1, status
             expect1 = "Regular expression error in '^a.*(e$': missing )"
             expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
-            assert stderr.find(expect1) != -1 or stderr.find(expect2) != -1, repr(
-                stderr
-            )
+            assert expect1 in stderr or expect2 in stderr, repr(stderr)
         finally:
             os.chdir(cwd)
 
@@ -1345,9 +1343,7 @@ sys.exit(0)
             assert status == 1, status
             expect1 = "Regular expression error in '^a.*(e$': missing )"
             expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
-            assert stderr.find(expect1) != -1 or stderr.find(expect2) != -1, repr(
-                stderr
-            )
+            assert expect1 in stderr or expect2 in stderr, repr(stderr)
         finally:
             os.chdir(cwd)
 

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -166,7 +166,7 @@ elif sys.platform == 'cygwin':
     lib_suffix = '.a'
     dll_prefix = 'cyg'
     dll_suffix = '.dll'
-elif sys.platform.find('irix') != -1:
+elif 'irix' in sys.platform:
     exe_suffix = ''
     obj_suffix = '.o'
     shobj_suffix = '.o'
@@ -175,7 +175,7 @@ elif sys.platform.find('irix') != -1:
     lib_suffix = '.a'
     dll_prefix = 'lib'
     dll_suffix = '.so'
-elif sys.platform.find('darwin') != -1:
+elif 'darwin' in sys.platform:
     exe_suffix = ''
     obj_suffix = '.o'
     shobj_suffix = '.os'
@@ -184,7 +184,7 @@ elif sys.platform.find('darwin') != -1:
     lib_suffix = '.a'
     dll_prefix = 'lib'
     dll_suffix = '.dylib'
-elif sys.platform.find('sunos') != -1:
+elif 'sunos' in sys.platform:
     exe_suffix = ''
     obj_suffix = '.o'
     shobj_suffix = '.pic.o'

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -335,7 +335,7 @@ class must_contain_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "", stdout
         stderr = run_env.stderr()
-        assert "No such file or directory:") in stderr, stderr
+        assert "No such file or directory" in stderr, stderr
 
     def test_failure(self) -> None:
         """Test must_contain():  failure"""

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -216,7 +216,7 @@ class must_be_writable_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_writable_file_exists(self) -> None:
         """Test must_be_writable():  writable file exists"""
@@ -260,7 +260,7 @@ class must_be_writable_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Unwritable files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_file_specified_as_list(self) -> None:
         """Test must_be_writable():  file specified as list"""
@@ -335,7 +335,7 @@ class must_contain_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "", stdout
         stderr = run_env.stderr()
-        assert stderr.find("No such file or directory:") != -1, stderr
+        assert "No such file or directory:") in stderr, stderr
 
     def test_failure(self) -> None:
         """Test must_contain():  failure"""
@@ -359,7 +359,7 @@ class must_contain_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == expect, f"got:\n{stdout}\nexpected:\n{expect}"
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_mode(self) -> None:
         """Test must_contain():  mode"""
@@ -454,7 +454,7 @@ class must_contain_all_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_find(self) -> None:
         """Test must_contain_all_lines():  find"""
@@ -530,7 +530,7 @@ class must_contain_all_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_contain_any_line_TestCase(TestCommonTestCase):
@@ -606,7 +606,7 @@ class must_contain_any_line_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_find(self) -> None:
         """Test must_contain_any_line():  find"""
@@ -681,7 +681,7 @@ class must_contain_any_line_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_contain_exactly_lines_TestCase(TestCommonTestCase):
@@ -789,7 +789,7 @@ class must_contain_exactly_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_find(self) -> None:
         """Test must_contain_exactly_lines():  find"""
@@ -875,7 +875,7 @@ class must_contain_exactly_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_contain_lines_TestCase(TestCommonTestCase):
@@ -949,7 +949,7 @@ class must_contain_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_exist_TestCase(TestCommonTestCase):
@@ -984,7 +984,7 @@ class must_exist_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_failure_message(self) -> None:
         """Test must_exist():  failure with extra message"""
@@ -1000,7 +1000,7 @@ class must_exist_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("Extra Info") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_file_specified_as_list(self) -> None:
         """Test must_exist():  file specified as list"""
@@ -1071,7 +1071,7 @@ class must_exist_one_of_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing one of: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_failure_message(self) -> None:
         """Test must_exist_one_of():  failure with extra message"""
@@ -1087,7 +1087,7 @@ class must_exist_one_of_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing one of: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("Extra Info") != -1, stderr
+        assert 'Extra Info' in stderr, stderr
 
     def test_files_specified_as_list(self) -> None:
         """Test must_exist_one_of():  files specified as list"""
@@ -1192,7 +1192,7 @@ class must_match_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "", stdout
         stderr = run_env.stderr()
-        assert stderr.find("No such file or directory:") != -1, stderr
+        assert 'No such file or directory' in stderr, stderr
 
     def test_failure(self) -> None:
         """Test must_match():  failure"""
@@ -1221,7 +1221,7 @@ class must_match_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == expect, stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_mode(self) -> None:
         """Test must_match():  mode"""
@@ -1258,7 +1258,7 @@ class must_not_be_writable_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Missing files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_writable_file_exists(self) -> None:
         """Test must_not_be_writable():  writable file exists"""
@@ -1280,7 +1280,7 @@ class must_not_be_writable_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Writable files: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_non_writable_file_exists(self) -> None:
         """Test must_not_be_writable():  non-writable file exists"""
@@ -1360,7 +1360,7 @@ class must_not_contain_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "", stdout
         stderr = run_env.stderr()
-        assert stderr.find("No such file or directory:") != -1, stderr
+        assert 'No such file or directory' in stderr, stderr
 
     def test_failure(self) -> None:
         """Test must_not_contain():  failure"""
@@ -1385,7 +1385,7 @@ class must_not_contain_TestCase(TestCommonTestCase):
         assert stdout == expect, f"\ngot:\n{stdout}\nexpected:\n{expect}"
 
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_failure_index_0(self) -> None:
         """Test must_not_contain():  failure at index 0"""
@@ -1410,7 +1410,7 @@ class must_not_contain_TestCase(TestCommonTestCase):
         assert stdout == expect, f"\ngot:\n{stdout}\nexpected:\n{expect}"
 
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_mode(self) -> None:
         """Test must_not_contain():  mode"""
@@ -1478,7 +1478,7 @@ class must_not_contain_any_line_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_find(self) -> None:
         """Test must_not_contain_any_line():  find"""
@@ -1584,7 +1584,7 @@ class must_not_contain_any_line_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_not_contain_lines_TestCase(TestCommonTestCase):
@@ -1631,7 +1631,7 @@ class must_not_contain_lines_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         stderr = run_env.stderr()
         assert stdout == expect, assert_display(expect, stdout, stderr)
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_success(self) -> None:
         """Test must_not_contain_lines():  success"""
@@ -1679,7 +1679,7 @@ class must_not_exist_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Unexpected files exist: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_success(self) -> None:
         """Test must_not_exist():  success"""
@@ -1730,7 +1730,7 @@ class must_not_exist_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Unexpected files exist: `brokenlink'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class must_not_exist_any_of_TestCase(TestCommonTestCase):
@@ -1765,7 +1765,7 @@ class must_not_exist_any_of_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "Unexpected files exist: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_files_specified_as_list(self) -> None:
         """Test must_not_exist_any_of():  files specified as list"""
@@ -1855,7 +1855,7 @@ class must_not_be_empty_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "File is empty: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
     def test_success(self) -> None:
         """Test must_not_be_empty():  success"""
@@ -1888,7 +1888,7 @@ class must_not_be_empty_TestCase(TestCommonTestCase):
         stdout = run_env.stdout()
         assert stdout == "File doesn't exist: `file1'\n", stdout
         stderr = run_env.stderr()
-        assert stderr.find("FAILED") != -1, stderr
+        assert 'FAILED' in stderr, stderr
 
 
 class run_TestCase(TestCommonTestCase):

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -954,7 +954,7 @@ if True:
                     if os.path.exists(home):
                         return home
             else:
-                if java_home.find(f'jdk{version}') != -1:
+                if f'jdk{version}' in java_home:
                     return java_home
                 for home in [
                     f'/System/Library/Frameworks/JavaVM.framework/Versions/{version}/Home',
@@ -1066,7 +1066,7 @@ if True:
         stderr = self.stderr() or ""
         if version:
             verf = f'javac {version}'
-            if stderr.find(verf) == -1 and stdout.find(verf) == -1:
+            if verf not in stderr and verf not in stdout:
                 fmt = "Could not find javac for Java version %s, skipping test(s).\n"
                 self.skip_test(fmt % version, from_fw=True)
         else:
@@ -1080,7 +1080,7 @@ if True:
                 self.javac_is_gcj = False
                 return where_javac, version
 
-            if stderr.find('gcj') != -1:
+            if 'gcj' in stderr:
                 version = '1.2'
                 self.javac_is_gcj = True
             else:
@@ -1393,10 +1393,8 @@ SConscript(sconscript)
 
             if (
                 doCheckLog
-                and logfile.find(
-                    "scons: warning: The stored build information has an unexpected class."
-                )
-                >= 0
+                and "scons: warning: The stored build information has an unexpected class."
+                in logfile
             ):
                 self.fail_test()
 
@@ -1559,10 +1557,8 @@ SConscript(sconscript)
 
             if (
                 doCheckLog
-                and logfile.find(
-                    "scons: warning: The stored build information has an unexpected class."
-                )
-                >= 0
+                and "scons: warning: The stored build information has an unexpected class."
+                in logfile
             ):
                 self.fail_test()
 


### PR DESCRIPTION
A maintenance edit: most instances of `str.find()` used for membership checks like `if foo.find('bar') != -1` are replaced with `in` or `not in`, or in a few cases, with the `startswith()` method.  The vendored docbook utilities were not changed in this round though they had a couple of these.

This is all-internal, no behavioral changes, so no doc impacts.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
