### PR TITLE
Update subst docstrings and minor formatting

### DIFF
--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -25,14 +25,17 @@
 
 A substitution mini-language describes how SCons performs token
 replacement on strings or lists of strings that are intended for use
-in commands.  ``${expression}`` is the primary format. ``expression`` can
-refer to a construction variable within a given environment or to a Python
-expression. The curly braces can be omitted for variable references, if
-there is no ambiguity with following text. Doubling the ``$`` escapes
-its special meaning. THe sequence ``$(subexpression$)`` is used to
-indicate ``subexpression`` should be included in the substituted string
-if substitution is for a command line, and omitted if the substitution
-is to produce a string for signature (hash) computation.
+in actions.  A replaceble element is specified as ``${expression}``.
+``expression`` can refer to a construction variable within a given
+environment or to a Python expression. The curly braces can be omitted
+for variable references if there is no ambiguity with the following text.
+For technical reasons the unbraced ``$var`` form is preferable when it can
+be used.  Doubling the ``$`` escapes its special meaning. The sequence
+``$(subexpression$)`` is used to indicate ``subexpression`` should be
+included in the substituted string if substitution is intended for a
+command line, and omitted if the substitution is to produce a string for
+signature (hash) computation. THe begin/end markers are always omitted
+in the substituted text.
 
 Substitution is recursive: the token replacement may produce new
 substitutable sequences, and work has to proceed until there are no more.
@@ -76,7 +79,7 @@ def raise_exception(exception, target, s):
 
 
 class Literal:
-    """A wrapper for non-subsitutable strings.
+    """A wrapper for non-substitutable strings.
 
     The substitution logic will not change the wrapped string.
     When passed to the command interpreter, all special
@@ -476,6 +479,7 @@ class StringSubber:
                 return conv(substitute(l, lvars))
 
             return list(map(func, s))
+
         if callable(s):
 
             # SCons has the unusual Null class where any __getattr__ call returns it's self,

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -25,17 +25,18 @@
 
 A substitution mini-language describes how SCons performs token
 replacement on strings or lists of strings that are intended for use
-in actions.  A replaceble element is specified as ``${expression}``.
-``expression`` can refer to a construction variable within a given
-environment or to a Python expression. The curly braces can be omitted
-for variable references if there is no ambiguity with the following text.
-For technical reasons the unbraced ``$var`` form is preferable when it can
-be used.  Doubling the ``$`` escapes its special meaning. The sequence
-``$(subexpression$)`` is used to indicate ``subexpression`` should be
-included in the substituted string if substitution is intended for a
-command line, and omitted if the substitution is to produce a string for
-signature (hash) computation. THe begin/end markers are always omitted
-in the substituted text.
+in actions. A replaceable element is specified as ``${expression}``,
+where ``expression`` is all the characters up to the matching closing
+brace. If ``expression`` is a construction variable reference, the
+braces can be omitted (this is preferred for performance reasons), in
+which case the expression ends at the first character not valid in a
+Python identifier. ``expression`` can also be Python code, which always
+requires braces. ``$(subexpression$)`` is used to indicate text to be
+included in the substituted string when a command line is being produced,
+and omitted if the string is being produced for signature (hash) calculation.
+The begin/end markers are always omitted in the substituted text.
+The special meaning of ``$`` can be escaped by doubling it, which
+eventually produces a single ``$`` in the output.
 
 Substitution is recursive: the token replacement may produce new
 substitutable sequences, and work has to proceed until there are no more.
@@ -423,8 +424,8 @@ class StringSubber:
             if s1 == '$':
                 # In this case keep the double $'s which we'll later
                 # swap for a single dollar sign as we need to retain
-                # this information to properly avoid matching "$("" when
-                # the actual text was "$$(""  (or "$)"" when "$$)"" )
+                # this information to properly avoid matching "$(" when
+                # the actual text was "$$("  (or "$)" when "$$)" )
                 return '$$'
             elif s1 in '()':
                 return s
@@ -543,9 +544,9 @@ class StringSubber:
 class ListSubber(UserList):
     """A class to construct the results of a scons_subst_list() call.
 
-    Like StringSubber, this class binds a specific construction
-    environment, mode, target and source with two methods
-    (substitute() and expand()) that handle the expansion.
+    Like :class:`StringSubber:class:`, this class binds a specific
+    construction environment, mode, target and source with two methods
+    (:meth:`substitute` and :meth:`expand`) that handle the expansion.
 
     In addition, however, this class is used to track the state of
     the result(s) we're gathering so we can do the appropriate thing
@@ -572,11 +573,11 @@ class ListSubber(UserList):
         self.next_line()
 
     def expanded(self, s) -> bool:
-        """Determines if the string s requires further expansion.
+        """Determine if the string *s* requires further expansion.
 
-        Due to the implementation of ListSubber expand will call
-        itself 2 additional times for an already expanded string. This
-        method is used to determine if a string is already fully
+        Due to the implementation of :class:`ListSubber`, :meth:`expand`
+        will call itself 2 additional times for an already expanded string.
+        This method is used to determine if a string is already fully
         expanded and if so exit the loop early to prevent these
         recursive calls.
         """
@@ -878,7 +879,7 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={
     substitutions.
 
     This is the work-horse function for substitutions in file names
-    and the like.  The companion scons_subst_list() function (below)
+    and the like.  The companion :func:`scons_subst_list` function
     handles separating command lines into lists of arguments, so see
     that function if that's what you're looking for.
     """
@@ -959,7 +960,7 @@ def scons_subst_list(strSubst, env, mode=SUBST_RAW, target=None, source=None, gv
     """Substitute construction variables in a string (or list or other
     object) and separate the arguments into a command list.
 
-    The companion scons_subst() function (above) handles basic
+    The companion :func:`scons_subst` function handles basic
     substitutions within strings, so see that function instead
     if that's what you're looking for.
     """
@@ -1009,7 +1010,7 @@ def scons_subst_once(strSubst, env, key):
 
     This is used when setting a variable when copying or overriding values
     in an Environment.  We want to capture (expand) the old value before
-    we override it, so people can do things like:
+    we override it, so people can do things like::
 
         env2 = env.Clone(CCFLAGS = '$CCFLAGS -g')
 

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -85,6 +85,10 @@ class Literal:
     The substitution logic will not change the wrapped string.
     When passed to the command interpreter, all special
     characters will be escaped and/or the string quoted.
+
+    Note that since we do not subclass :mod:`~collections.UserString`,
+    :func:`~SCons.Util.sctypes.is_String` will not identify this as a string,
+    and :func:`~SCons.Util.sctypes.to_String` won't return the enclosed string.
     """
 
     def __init__(self, lstr) -> None:
@@ -131,8 +135,12 @@ class SpecialAttrWrapper:
     so we can return some canonical string during signature
     calculation to avoid unnecessary rebuilds.
 
-    If the *for_signature* parameter if supplied at creation time,
+    If the *for_signature* parameter is supplied at creation time,
     :meth:`for_signature` will return that when called, else the original.
+
+    Note that since we do not subclass :mod:`~collections.UserString`,
+    :func:`~SCons.Util.sctypes.is_String` will not identify this as a string,
+    and :func:`~SCons.Util.sctypes.to_String` won't return the enclosed string.
     """
 
     def __init__(self, lstr: str, for_signature: str | None = None) -> None:


### PR DESCRIPTION
This is a no-code change (1) - addition or modification of docstrings, adding blank lines for readability, fixing spacing between code and comment, and a few typing annotations.

1. there are a few instances of `else` dropped or `elif` turned to `if` when the previous block ended with `return` or `raise`.  Those are *technically* code changes, but have no behavioral effect.
