### PR TITLE
Try to call Override less

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines
+    - Reduce unneeded computation of overrides. The Mkdir builder used an
+      unknown argument ('explain') on creation, causing it to be considered
+      an override. Also, if override dict is empty, don't even call the
+      Override factory function.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -41,6 +41,11 @@ IMPROVEMENTS
   documentation:  performance improvements (describe the circumstances
   under which they would be observed), or major code cleanups
 
+- Reduce unneeded computation of overrides. The Mkdir builder used an
+  unknown argument ('explain') on creation, causing it to be considered
+  an override. Also, if override dict is empty, don't even call the
+  Override factory function.
+
 PACKAGING
 ---------
 

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -670,8 +670,8 @@ class BuilderBase:
         else:
             env_kw = self.overrides
 
-        # TODO if env_kw: then the following line. there's no purpose in calling if no overrides.
-        env = env.Override(env_kw)
+        if env_kw:  # there's no purpose in calling if no overrides.
+            env = env.Override(env_kw)
         return self._execute(env, target, source, OverrideWarner(kw), ekw)
 
     def adjust_suffix(self, suff):

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -859,9 +859,12 @@ class SubstitutionEnvironment:
            A proxy environment of type :class:`OverrideEnvironment`.
            or the current environment if *overrides* is empty.
         """
-        if not overrides: return self
+        # belt-and-suspenders - main callers should already have checked:
+        if not overrides:
+            return self
         o = copy_non_reserved_keywords(overrides)
-        if not o: return self
+        if not o:
+            return self
         overrides = {}
         merges = None
         for key, value in o.items():

--- a/SCons/Executor.py
+++ b/SCons/Executor.py
@@ -168,21 +168,18 @@ class Executor(metaclass=NoSlotsPyPy):
                  '_do_execute',
                  '_execute_str')
 
-    def __init__(self, action, env=None, overridelist=[{}],
-                 targets=[], sources=[], builder_kw={}) -> None:
+    def __init__(self, action, env=None, overridelist=None,
+                 targets=[], sources=[], builder_kw=None) -> None:
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Executor.Executor')
         self.set_action_list(action)
         self.pre_actions = []
         self.post_actions = []
         self.env = env
-        self.overridelist = overridelist
-        if targets or sources:
-            self.batches = [Batch(targets[:], sources[:])]
-        else:
-            self.batches = []
-        self.builder_kw = builder_kw
-        self._do_execute = 1
-        self._execute_str = 1
+        self.overridelist = [{}] if overridelist is None else overridelist
+        self.batches = [Batch(targets[:], sources[:])] if targets or sources else []
+        self.builder_kw = {} if builder_kw is None else builder_kw
+        self._do_execute: int = 1  # map key
+        self._execute_str: int = 1  # map key
         self._memo = {}
 
     def get_lvars(self):
@@ -358,7 +355,7 @@ class Executor(metaclass=NoSlotsPyPy):
 
         import SCons.Defaults
         env = self.env or SCons.Defaults.DefaultEnvironment()
-        build_env = env.Override(overrides)
+        build_env = env.Override(overrides) if overrides else env
 
         self._memo['get_build_env'] = build_env
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -381,7 +381,6 @@ def get_MkdirBuilder():
         # calling SCons.Defaults.DefaultEnvironment() when necessary.
         MkdirBuilder = SCons.Builder.Builder(action = Mkdir,
                                              env = None,
-                                             explain = None,
                                              is_explicit = None,
                                              target_scanner = SCons.Defaults.DirEntryScanner,
                                              name = "MkdirBuilder")


### PR DESCRIPTION
Eliminate a kwarg `explain` from the call to `Builder()` for `Mkdir`.  Arg is not used (maybe it was in the past, though have not found the evidence for this), which meant we had an override dict in this case. Suprisingly, this ended up in the override logic a *lot* in a build of a large sample project - over 2000 extra calls to `scons_subst_once` that weren't needed.

`Builder` and `Executor` both have places where they call `Override()`. While the `Override` factory indeed returns quickly if the override dict is empty, avoid the function call entirely in this case by checking (there was an old TODO comment to this effect in `Builder.__init__.py`).

The `Executor` init method declared multiple paramters with mutable defaults, which means they "persist". While there's no evidence this is calling a real problem, eliminate part of this footgun by defaulting `overridelist` and `builder_kw` to `None` and checking for that (`targets` and `sources` still default to a mutable empty list, a TBD perhaps).

There are no user-visible effects to these changes; existing tests have been run and indicate no impacts. Thus, there are no doc or test changes included.


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
