### PR TITLE
Improve details on top-relative paths in manpage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines
+    - More clarifications in manpage Builder Methods section.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -55,6 +55,8 @@ DOCUMENTATION
 
 - Fix SCons Docbook schema to work with lxml > 5
 
+- More clarifications in manpage Builder Methods section.
+
 
 DEVELOPMENT
 -----------

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2984,21 +2984,21 @@ env.Program('bar', source='bar.c foo.c'.split())
 Top-relative paths only work
 for objects that are participants in the build
 (sources and targets).
-To be used in other contexts
-(in particular, in pure &Python; code that does not
+The string must first be converted
+to a relative or absolute path
+to be used in other contexts
+(such as pure &Python; code that does not
 involve an &SCons; API call),
-the string must first be converted
-to a relative or absolute path.
 A suitable string can be extracted from the Node
 created from a top-relative path.
 Additionally, some paths are handled by &SCons; but
 are not directly build participants,
 so are not evaluated for the <literal>#</literal>
 since no Nodes are created.
-For example, the path to the derived-file cache set by
-a call to &f-link-CacheDir; is not entered
-into the dependency graph,
-but you can create a &f-link-Dir; node to force the evaluation.
+You can explcitly create a &f-link-File; or &f-link-Dir;
+node to force evaluation,
+such as when specifying a path to the derived-file cache:
+<literal>CacheDir(Dir('#cache'))</literal>.
 </para>
 </note>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2982,8 +2982,7 @@ env.Program('bar', source='bar.c foo.c'.split())
 <note>
 <para>
 Top-relative paths only work
-for objects that are participants in the build
-(sources and targets).
+where &SCons; will interpret the path (see examples).
 The string must first be converted
 to a relative or absolute path
 to be used in other contexts

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2981,12 +2981,24 @@ env.Program('bar', source='bar.c foo.c'.split())
 
 <note>
 <para>
-Top-relative paths <emphasis role="bold">only</emphasis> work
-where &SCons; will interpret the path (see examples).
-To be used in other contexts the string must first be converted
+Top-relative paths only work
+for objects that are participants in the build
+(sources and targets).
+To be used in other contexts
+(in particular, in pure &Python; code that does not
+involve an &SCons; API call),
+the string must first be converted
 to a relative or absolute path.
 A suitable string can be extracted from the Node
-created from the top-relative path.
+created from a top-relative path.
+Additionally, some paths are handled by &SCons; but
+are not directly build participants,
+so are not evaluated for the <literal>#</literal>
+since no Nodes are created.
+For example, the path to the derived-file cache set by
+a call to &f-link-CacheDir; is not entered
+into the dependency graph,
+but you can create a &f-link-Dir; node to force the evaluation.
 </para>
 </note>
 
@@ -3012,9 +3024,12 @@ env.Program('#/bar', 'bar.c')
 # SConstruct directory) from "subdir/foo.c":
 env.Program('#other/foo', 'foo.c')
 
-# This will not work, only SCons interfaces understand '#',
-# os.path.exists is pure Python:
+# os.path.exists() is pure Python, so this fails:
 if os.path.exists('#inc/foo.h'):
+    env.Append(CPPPATH='#inc')
+
+# create a Node to make it work:
+if os.path.exists(File('#inc/foo.h')):
     env.Append(CPPPATH='#inc')
 </programlisting>
 


### PR DESCRIPTION
Minor change: Builder Methods section: added a working stanza to the example to finish off the one that's shown as failing (`os.path.exists` on a `#`-path). Also note that even some paths specific to SCons don't get processed through the node system - showing the `CacheDir` path as an example.

Doc-only: no code or test impacts.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
