### PR TITLE
Handle `F401` exclusions more granularly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
+  From Thaddeus Crews:
+    - Ruff: Handle F401 exclusions more granularly, remove per-file exclusions.
+
   From William Deegan:
     - Fix SCons Docbook schema to work with lxml > 5
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -75,6 +75,8 @@ DEVELOPMENT
 
 - Introduce some unit tests for the file locking utility routines
 
+- Ruff: Handle F401 exclusions more granularly, remove per-file exclusions.
+
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text

--- a/SCons/Util/__init__.py
+++ b/SCons/Util/__init__.py
@@ -52,7 +52,6 @@ in multiple places, rather then being topical only to one module/package.
 from __future__ import annotations
 
 import copy
-import hashlib
 import logging
 import os
 import re
@@ -60,13 +59,12 @@ import sys
 import time
 from collections import UserDict, UserList, deque
 from contextlib import suppress
-from types import MethodType, FunctionType
 from typing import Any
 from logging import Formatter
 
 # Util split into a package. Make sure things that used to work
 # when importing just Util itself still work:
-from .sctypes import (
+from .sctypes import (  # noqa: F401
     DictTypes,
     ListTypes,
     SequenceTypes,
@@ -90,7 +88,7 @@ from .sctypes import (
     get_os_env_bool,
     get_environment_var,
 )
-from .hashes import (
+from .hashes import (  # noqa: F401
     ALLOWED_HASH_FORMATS,
     DEFAULT_HASH_FORMATS,
     get_hash_format,
@@ -103,7 +101,7 @@ from .hashes import (
     MD5filesignature,
     MD5collect,
 )
-from .envs import (
+from .envs import (  # noqa: F401
     MethodWrapper,
     PrependPath,
     AppendPath,
@@ -111,7 +109,7 @@ from .envs import (
     AddMethod,
     is_valid_construction_var,
 )
-from .filelock import FileLock, SConsLockFailure
+from .filelock import FileLock, SConsLockFailure  # noqa: F401
 
 PYPY = hasattr(sys, 'pypy_translation_info')
 

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -34,7 +34,6 @@ from typing import Any, Callable, Sequence
 
 import SCons.Errors
 import SCons.Util
-import SCons.Warnings
 
 # Note: imports are for the benefit of SCons.Main (and tests); since they
 #   are not used here, the "as Foo" form is for checkers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,14 +117,6 @@ extend-safe-fixes = ["FA", "UP006", "UP007"]
 [tool.ruff.format]
 quote-style = "preserve" # Equivalent to black's "skip-string-normalization"
 
-[tool.ruff.lint.per-file-ignores]
-"SCons/Util/__init__.py" = [
-    "F401",  # Module imported but unused
-]
-"SCons/Variables/__init__.py" = [
-    "F401",  # Symbol imported but unused
-]
-
 [tool.mypy]
 python_version = "3.8"
 exclude = [

--- a/test/Scanner/Python/script.py
+++ b/test/Scanner/Python/script.py
@@ -2,8 +2,8 @@
 #
 # Copyright The SCons Foundation
 
-import package1  # noqa: F401
-import package2  # noqa: F401
+import package1
+import package2
 import sys
 
 with open(sys.argv[1], 'w') as f:

--- a/test/Scanner/Python/to_be_copied/__init__.py
+++ b/test/Scanner/Python/to_be_copied/__init__.py
@@ -2,4 +2,4 @@
 #
 # Copyright The SCons Foundation
 
-from . import helper  # noqa: F401
+from . import helper

--- a/test/fixture/python_scanner/from_import_simple_package_module1_func.py
+++ b/test/fixture/python_scanner/from_import_simple_package_module1_func.py
@@ -2,4 +2,4 @@
 #
 # Copyright The SCons Foundation
 
-from simple_package.module1 import somefunc  # noqa: F401
+from simple_package.module1 import somefunc

--- a/test/fixture/python_scanner/from_nested1_import_multiple.py
+++ b/test/fixture/python_scanner/from_nested1_import_multiple.py
@@ -2,4 +2,4 @@
 #
 # Copyright The SCons Foundation
 
-from nested1 import module, nested2  # noqa: F401
+from nested1 import module, nested2

--- a/test/fixture/python_scanner/imports_unknown_files.py
+++ b/test/fixture/python_scanner/imports_unknown_files.py
@@ -2,6 +2,6 @@
 #
 # Copyright The SCons Foundation
 
-import doesntexist  # noqa: F401
-import notthere.something  # noqa: F401
-from notthere import a, few, things  # noqa: F401
+import doesntexist
+import notthere.something
+from notthere import a, few, things

--- a/test/option/debug-memory.py
+++ b/test/option/debug-memory.py
@@ -36,7 +36,7 @@ test = TestSCons.TestSCons()
 
 if not IS_WINDOWS:
     try:
-        import resource  # noqa: F401
+        import resource
     except ImportError:
         x = "Python version has no 'resource' skipping tests.\n"
         test.skip_test(x)


### PR DESCRIPTION
Was originally going to be a separate stylistic dive, but this discrepancy caught my eye so I wanted to handle it now. This removes the per-file exclusions of `F401`, instead handling them on a per-include basis. Also removed the exclusion from test files, as those are already explicitly setup to NOT get checked by Ruff

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
