### PR TITLE
Fix Sphinx build, again

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,6 +25,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       unknown argument ('explain') on creation, causing it to be considered
       an override. Also, if override dict is empty, don't even call the
       Override factory function.
+    - Handle the default (unset) ProgressObject differently for the sole
+      purpose of avoiding Sphinx 9.0+ blowing up on it (it's been giving
+      a warning for years, but now it's a fatal error).
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -62,6 +62,11 @@ DOCUMENTATION
 
 - More clarifications in manpage Builder Methods section.
 
+- Handle the default (unset) ProgressObject differently for the sole
+  purpose of avoiding Sphinx 9.0+ blowing up on it (it's been giving
+  a warning for years, but now it's a fatal error). Affects only the
+  API doc build.
+
 
 DEVELOPMENT
 -----------

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -178,7 +178,7 @@ class Progressor:
                 self.erase_previous()
             self.func(node)
 
-ProgressObject = SCons.Util.Null()
+ProgressObject = None
 
 def Progress(*args, **kw) -> None:
     """Show progress during building - Public API."""
@@ -203,7 +203,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
         display('scons: ' + message)
 
     def prepare(self):
-        if not isinstance(self.progress, SCons.Util.Null):
+        if self.progress is not None:
             for target in self.targets:
                 self.progress(target)
         return SCons.Taskmaster.OutOfDateTask.prepare(self)

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -144,7 +144,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
The release of Sphinx 9 brought a rewritten autodoc plugin, which now fails on one use of the `SCons.Util.Null` class that it's been issuing a warning since we started using Sphinx (could never find the cause). Found the location - the default value of the `ProgressObject` is `Null`, and that caused the problem. Not entirely sure why, but that usage doesn't need a `Null`, since it checks for a sentinel, so just switch it to use `None`.

Also comment out one unused feature in the Sphinx config that issued a warning.

Only affects the doc build. 

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
