### PR TITLE
Improve coverage of API doc build

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Handle the default (unset) ProgressObject differently for the sole
       purpose of avoiding Sphinx 9.0+ blowing up on it (it's been giving
       a warning for years, but now it's a fatal error).
+    - Improve covarage of API doc build by ignoring any setting of
+      __all__ in a package and not showing inherited members from optparse.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -67,6 +67,10 @@ DOCUMENTATION
   a warning for years, but now it's a fatal error). Affects only the
   API doc build.
 
+- Improve covarage of API doc build by ignoring any setting of
+  __all__ in a package and not showing inherited members from optparse.
+
+
 
 DEVELOPMENT
 -----------

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -21,7 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Adds user-friendly customizable variables to an SCons build."""
+"""
+Adds user-friendly customizable variables to an SCons build.
+
+"Build Variables" represent a way to supply values for SCons
+construction variables from the command-line, or from saved settings files.
+"""
 
 from __future__ import annotations
 
@@ -57,8 +62,27 @@ __all__ = [
 
 @dataclass(order=True)
 class Variable:
-    """A Build Variable."""
-    __slots__ = ('key', 'aliases', 'help', 'default', 'validator', 'converter', 'do_subst')
+    """A Build Variable.
+
+    Attributes:
+       key: the name of the variable
+       aliases: other names recognized for the variable
+       help:– help text
+       default: optional default value
+       validator: optional validator function
+       converter: optional converter function
+       do_subst: substitute before calling converter/valiator (default True)
+    """
+
+    __slots__ = (
+        'key',
+        'aliases',
+        'help',
+        'default',
+        'validator',
+        'converter',
+        'do_subst',
+    )
     key: str
     aliases: list[str]
     help: str

--- a/doc/sphinx/SCons.Script.rst
+++ b/doc/sphinx/SCons.Script.rst
@@ -33,6 +33,7 @@ SCons.Script.SConsOptions module
 --------------------------------
 
 .. automodule:: SCons.Script.SConsOptions
+    :no-inherited-members:
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/sphinx/SCons.Variables.rst
+++ b/doc/sphinx/SCons.Variables.rst
@@ -5,6 +5,7 @@ Module contents
 ---------------
 
 .. automodule:: SCons.Variables
+    :ignore-module-all:
     :members:
     :undoc-members:
     :show-inheritance:
@@ -17,6 +18,7 @@ SCons.Variables.BoolVariable module
 -----------------------------------
 
 .. automodule:: SCons.Variables.BoolVariable
+    :ignore-module-all:
     :members:
     :undoc-members:
     :show-inheritance:
@@ -25,6 +27,7 @@ SCons.Variables.EnumVariable module
 -----------------------------------
 
 .. automodule:: SCons.Variables.EnumVariable
+    :ignore-module-all:
     :members:
     :undoc-members:
     :show-inheritance:
@@ -33,6 +36,8 @@ SCons.Variables.ListVariable module
 -----------------------------------
 
 .. automodule:: SCons.Variables.ListVariable
+    :ignore-module-all:
+    :no-inherited-members:
     :members:
     :undoc-members:
     :show-inheritance:
@@ -41,6 +46,7 @@ SCons.Variables.PackageVariable module
 --------------------------------------
 
 .. automodule:: SCons.Variables.PackageVariable
+    :ignore-module-all:
     :members:
     :undoc-members:
     :show-inheritance:
@@ -49,6 +55,7 @@ SCons.Variables.PathVariable module
 -----------------------------------
 
 .. automodule:: SCons.Variables.PathVariable
+    :ignore-module-all:
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Tell Sphinx to Ignore setting of `__all__` in `SCons.Variables` (would ignore elsewhere but that's the only current user), it was skipping some of the content of `Variables` previously.  Don't show inherited members for `SCons.Script.SConsOptions`, there's little docstring content for stdlib `optparse`, and this is a place where it's clearer if we see only the things SCons extends.  Tweak a few docstrings in `SConsOptions`, too.

Doc-only change.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
