### PR TITLE
Tweak the project/package dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,15 +52,18 @@ scons = "SCons.Script.Main:main"
 sconsign = "SCons.Utilities.sconsign:main"
 scons-configure-cache = "SCons.Utilities.ConfigureCache:main"
 
-[project.optional-dependencies]
+# Extra deps for development.
+[dependency-groups]
 dev = [
     "ninja",
     "psutil",
     "lxml",
 ]
+# there's no official syntax for "include @dev" yet, so repeat:
 pkg = [
     "ninja",
     "psutil",
+    "lxml",
     "readme-renderer",
     "sphinx",
     "sphinx-book-theme",
@@ -68,7 +71,12 @@ pkg = [
     "build",
     "twine",
     "packaging",
+    # pdf doc build suggests this for better results, excluded for now:
+    # "matplotlib",
 ]
+
+# Features users can opt into. Currently none.
+# [project.optional-dependencies]
 
 [tool.setuptools]
 zip-safe = false
@@ -127,7 +135,9 @@ quote-style = "preserve" # Equivalent to black's "skip-string-normalization"
 ]
 
 [tool.mypy]
-python_version = "3.8"
+# version should be oldest supported by SCons, but mypy has moved on.
+# can't *run* mypy with 3.9, but can still check against it, for now.
+python_version = "3.9"
 exclude = [
     "^bench/",
     "^bin/",
@@ -139,3 +149,5 @@ exclude = [
     "^timings/",
     "^SCons/Tool/docbook/docbook-xsl-1.76.1/",
 ]
+
+# TODO: need a matching section for pyright? (doesn't read [tool.mypy]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,16 @@
 # Dependencies for development - mainly for running tests
+#
+# You can alternativey use: pip install scons[dev]
+# to pick up the dependencies from pyproject.toml
 
 -r requirements.txt
 
-# for now keep pinning "known working" lxml,
-# it's been a troublesome component in the past.
-# Skip  lxml for win32 as no tests which require it currently pass on win32
-lxml<5; python_version < '3.13' and sys_platform != 'win32'
-lxml>=5.0.0; python_version >= '3.13'
+# pin lxml if it breaks on a new release, which has happened many times.
+# we used to skip lxml on win32 as no tests which require it currently
+# pass on Windows anyway, and as we don't build docs on Windows either.
+# Add the exclusion back if it's found to cause trouble.
+# lxml and sys.platform != 'win32'
+lxml
 
 ninja
 

--- a/requirements-pkg.txt
+++ b/requirements-pkg.txt
@@ -1,4 +1,7 @@
-# Dependencies for packaging, and distribution, including the docs build
+# Dependencies for packaging and distribution, including the docs build
+#
+# You can alternatively use: pip install scons[pkg]
+# to pick up the dependencies from pyproject.toml
 
 -r requirements-dev.txt
 
@@ -7,10 +10,12 @@
 # See: https://github.com/pypa/readme_renderer
 readme-renderer
 
-# sphinx pinned because it has broken several times on new releases
+# pin sphinx if it breaks on a new release, which has happened many times.
 sphinx
 sphinx-book-theme
 rst2pdf
+# pdf doc build suggests this for better results, excluded for now:
+# "matplotlib",
 
 build
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 # No dependencies for running SCons
+#
+# This file isn't really needed as any required deps covered by pyproject.toml


### PR DESCRIPTION
No SCons changes, just package metadata and deps

Moving the deps to `[dependency-groups]` allows provisioning local environments and CI without a requirments file like this:
```
pip install --group dev
```
for tests. For package/doc builds:
```
pip install --group pkg
```
