### PR TITLE
Fix debug include printing for multi-source

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -35,6 +35,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       a warning for years, but now it's a fatal error).
     - Improve covarage of API doc build by ignoring any setting of
       __all__ in a package and not showing inherited members from optparse.
+    - Fix --debug=includes for case of multiple source files.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -34,6 +34,8 @@ FIXES
 
 - List fixes of outright bugs
 
+- Fix --debug=includes for case of multiple source files.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -1558,25 +1558,26 @@ class Node(metaclass=NoSlotsPyPy):
         the command interpreter literally."""
         return True
 
-    def render_include_tree(self):
+    def render_include_tree(self) -> str:
         """
         Return a text representation, suitable for displaying to the
         user, of the include tree for the sources of this node.
         """
-        if self.is_derived():
-            env = self.get_build_env()
-            if env:
-                for s in self.sources:
-                    scanner = self.get_source_scanner(s)
-                    if scanner:
-                        path = self.get_build_scanner_path(scanner)
-                    else:
-                        path = None
-                    def f(node: Node, env: Environment = env, scanner: ScannerBase = scanner, path=path):
-                        return node.get_found_includes(env, scanner, path)
-                    return render_tree(s, f, 1)
-        else:
-            return None
+        if not self.is_derived():  # quick bailout
+            return ""
+
+        tree = ""
+        env = self.get_build_env()
+        if env:
+            for s in self.sources:
+                scanner = self.get_source_scanner(s)
+                if scanner:
+                    path = self.get_build_scanner_path(scanner)
+                else:
+                    path = None
+                tree += render_tree(s, lambda node: node.get_found_includes(env, scanner, path), prune=True)
+
+        return tree
 
     def get_abspath(self) -> str:
         """

--- a/test/option/debug-includes-multi.py
+++ b/test/option/debug-includes-multi.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test that the --debug=includes option prints the implicit
+dependencies of a target.
+
+A separate test to make sure it works if there is more than one source.
+The main test uses a C compiler, and object builders there are
+single-source, so we need a different scheme.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write('SConstruct', """
+import os
+import os.path
+import sys
+
+DefaultEnvironment(tools=[])
+
+def buildIt(env, target, source):
+    with open(target[0], 'w') as ofp:
+        for out in source:
+            with open(source[0], 'r') as ifp:
+                ofp.write(ifp.read())
+    return 0
+
+def source_scanner(node, env, path, builder):
+    return [File('a.inc'), File('b.inc')]
+
+env = Environment(tools=[])
+env.Command(
+    target="f.out",
+    source=["f1.in", "f2.in"],
+    action=buildIt,
+    source_scanner=Scanner(
+        lambda node, env, path: source_scanner(node, env, path, "w-env")
+    )
+)
+""")
+
+# the contents of these sources/includes don't matter
+test.write('f1.in', "f1.in\n")
+test.write('f2.in', "f2.in\n")
+test.write('a.inc', "a.inc\n")
+test.write('b.inc', "b.inc\n")
+
+expect = """
++-f1.in
+  +-a.inc
+  | +-[a.inc]
+  | +-b.inc
+  |   +-[a.inc]
+  |   +-[b.inc]
+  +-[b.inc]
++-f2.in
+  +-a.inc
+  | +-[a.inc]
+  | +-b.inc
+  |   +-[a.inc]
+  |   +-[b.inc]
+  +-[b.inc]
+"""
+test.run(arguments="-Q --debug=includes f.out")
+test.must_contain_all_lines(test.stdout(), [expect])
+
+test.pass_test()

--- a/test/option/debug-includes.py
+++ b/test/option/debug-includes.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the --debug=includes option prints the implicit
 dependencies of a target.
+
+This is currently a "live" test, requiring a C toolchain to execute.
 """
 
 import TestSCons
@@ -35,13 +36,14 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
-env = Environment(OBJSUFFIX = '.obj',
-                  SHOBJSUFFIX = '.shobj',
-                  LIBPREFIX = '',
-                  LIBSUFFIX = '.lib',
-                  SHLIBPREFIX = '',
-                  SHLIBSUFFIX = '.shlib',
-                  )
+env = Environment(
+    OBJSUFFIX='.obj',
+    SHOBJSUFFIX='.shobj',
+    LIBPREFIX='',
+    LIBSUFFIX='.lib',
+    SHLIBPREFIX='',
+    SHLIBSUFFIX='.shlib',
+)
 env.Program('foo.exe', ['foo.c', 'bar.c'])
 env.StaticLibrary('foo', ['foo.c', 'bar.c'])
 env.SharedLibrary('foo', ['foo.c', 'bar.c'], no_import_lib=True)
@@ -83,11 +85,9 @@ includes = """
   +-foo.h
     +-bar.h
 """
-test.run(arguments = "--debug=includes foo.obj")
+test.run(arguments="--debug=includes foo.obj")
 
 test.must_contain_all_lines(test.stdout(), [includes])
-
-
 
 # In an ideal world, --debug=includes would also work when there's a build
 # failure, but this would require even more complicated logic to scan
@@ -108,16 +108,13 @@ test.must_contain_all_lines(test.stdout(), [includes])
 #         stderr = None)
 #test.must_contain_all_lines(test.stdout(), [includes])
 
-
-
 # These shouldn't print out anything in particular, but
 # they shouldn't crash either:
-test.run(arguments = "--debug=includes .")
-test.run(arguments = "--debug=includes foo.c")
-test.run(arguments = "--debug=includes foo.lib")
-test.run(arguments = "--debug=includes foo.shlib")
-
-
+# TODO: not really true... the two library ones do emit something. Check?
+test.run(arguments="--debug=includes .")
+test.run(arguments="--debug=includes foo.c")
+test.run(arguments="--debug=includes foo.lib")
+test.run(arguments="--debug=includes foo.shlib")
 
 test.pass_test()
 


### PR DESCRIPTION
Rather obscure bug - if `--debug=includes` is selected, the analysis stopped after the first source file of a given target. For the common case of C/C++ projects, the object builders are single-source, so the problem would not be noticed.

Adds a distinct testcase, because the main debug-includes test uses the C compiler, which won't trigger this.

No doc impacts, although the documentation of the option could perhaps be a little more explicit.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
