### PR TITLE
Use "include-group" syntax in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,8 @@ dev = [
     "psutil",
     "lxml",
 ]
-# there's no official syntax for "include @dev" yet, so repeat:
 pkg = [
-    "ninja",
-    "psutil",
-    "lxml",
+    { include-group = "dev" },
     "readme-renderer",
     "sphinx",
     "sphinx-book-theme",


### PR DESCRIPTION
- Follow-up to #4798

Small fix to dependency group setup, as an official "`include @dev`" syntax *does* exist: [`{ include-group = "dev" }`](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-group-include).