### PR TITLE
Unify usage of a sentinel

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve covarage of API doc build by ignoring any setting of
       __all__ in a package and not showing inherited members from optparse.
     - Fix --debug=includes for case of multiple source files.
+    - Unify internal "_null" sentinel usage.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -80,10 +80,11 @@ DEVELOPMENT
 - List visible changes in the way SCons is developed
 
 - Introduce some unit tests for the file locking utility routines
-
 - Implement type hints for Node subclasses.
 - Ruff: Handle F401 exclusions more granularly, remove per-file exclusions.
 - Update pyproject.toml to support Python 3.14 and remove restrictions on lxml version install
+- Unify internal "_null" sentinel usage.
+
 
 
 Thanks to the following contributors listed below for their contributions to this release.

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -117,6 +117,7 @@ import SCons.Debug
 import SCons.Errors
 import SCons.Subst
 import SCons.Util
+from SCons.Util.sctypes import _null
 
 # we use these a lot, so try to optimize them
 from SCons.Debug import logInstanceCreation
@@ -125,9 +126,6 @@ from SCons.Util import is_String, is_List
 
 if TYPE_CHECKING:
     from SCons.Executor import Executor
-
-class _null:
-    pass
 
 print_actions = True
 execute_actions = True

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -115,11 +115,7 @@ from SCons.Debug import logInstanceCreation
 from SCons.Errors import InternalError, UserError
 from SCons.Executor import Executor
 from SCons.Node import Node
-
-class _Null:
-    pass
-
-_null = _Null
+from SCons.Util.sctypes import _null
 
 def match_splitext(path, suffixes = []):
     if suffixes:

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -78,14 +78,10 @@ from SCons.Util import (
     to_String_for_subst,
     uniquer_hashables,
 )
+from SCons.Util.sctypes import _null
 
 if TYPE_CHECKING:
     from SCons.Executor import Executor
-
-class _Null:
-    pass
-
-_null = _Null
 
 _warn_copy_deprecated = True
 _warn_source_signatures_deprecated = True

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -29,18 +29,14 @@ import re
 import SCons.Node.FS
 import SCons.Util
 import SCons.Warnings
+# Used as a return value of modify_env_var if the variable is not set.
+from SCons.Util.sctypes import _null
 from . import ScannerBase, FindPathDirs
 
 # list of graphics file extensions for TeX and LaTeX
 TexGraphics   = ['.eps', '.ps']
 #LatexGraphics = ['.pdf', '.png', '.jpg', '.gif', '.tif']
 LatexGraphics = [ '.png', '.jpg', '.gif', '.tif']
-
-
-# Used as a return value of modify_env_var if the variable is not set.
-class _Null:
-    pass
-_null = _Null
 
 # The user specifies the paths in env[variable], similar to other builders.
 # They may be relative and must be converted to absolute, as expected

--- a/SCons/Scanner/__init__.py
+++ b/SCons/Scanner/__init__.py
@@ -28,14 +28,7 @@ import re
 import SCons.Node.FS
 import SCons.PathList
 import SCons.Util
-
-
-class _Null:
-    pass
-
-# This is used instead of None as a default argument value so None can be
-# used as an actual argument value.
-_null = _Null
+from SCons.Util.sctypes import _null
 
 def Scanner(function, *args, **kwargs):
     """Factory function to create a Scanner Object.

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -31,6 +31,7 @@ import re
 
 import SCons.Util
 import SCons.Warnings
+from SCons.Util.sctypes import _null
 
 class XgettextToolWarning(SCons.Warnings.SConsWarning):
     pass
@@ -245,7 +246,7 @@ class _POFileBuilder(BuilderBase):
         return SCons.Node.NodeList(result)
 
 
-def _translate(env, target=None, source=SCons.Environment._null, *args, **kw):
+def _translate(env, target=None, source=_null, *args, **kw):
     """ Function for `Translate()` pseudo-builder """
     if target is None: target = []
     pot = env.POTUpdate(None, source, *args, **kw)

--- a/SCons/Tool/dvipdf.py
+++ b/SCons/Tool/dvipdf.py
@@ -34,11 +34,11 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.Action
 import SCons.Defaults
+import SCons.Scanner.LaTeX
 import SCons.Tool.pdf
 import SCons.Tool.tex
 import SCons.Util
-
-_null = SCons.Scanner.LaTeX._null
+from SCons.Util.sctypes import _null
 
 def DviPdfPsFunction(XXXDviAction, target = None, source= None, env=None):
     """A builder for DVI files that sets the TEXPICTS environment

--- a/SCons/Tool/msginit.py
+++ b/SCons/Tool/msginit.py
@@ -30,7 +30,6 @@ import SCons.Action
 import SCons.Tool
 import SCons.Util
 import SCons.Warnings
-from SCons.Environment import _null
 from SCons.Errors import StopError
 from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
 from SCons.Platform.mingw import MINGW_DEFAULT_PATHS
@@ -41,6 +40,7 @@ from SCons.Tool.GettextCommon import (
     # MsginitToolWarning,
     _POFileBuilder,
 )
+from SCons.Util.sctypes import _null
 
 
 def _optional_no_translator_flag(env):

--- a/SCons/Tool/msgmerge.py
+++ b/SCons/Tool/msgmerge.py
@@ -39,6 +39,7 @@ from SCons.Tool.GettextCommon import (
     # MsgmergeToolWarning,
     _POFileBuilder,
 )
+from SCons.Util.sctypes import _null
 
 def _update_or_init_po_files(target, source, env):
     """ Action function for `POUpdate` builder """
@@ -59,9 +60,6 @@ def _POUpdateBuilder(env, **kw):
 
     action = SCons.Action.Action(_update_or_init_po_files, None)
     return _POFileBuilder(env, action=action, target_alias='$POUPDATE_ALIAS')
-
-
-from SCons.Environment import _null
 
 
 def _POUpdateBuilderWrapper(env, target=None, source=_null, **kw):

--- a/SCons/Tool/tex.py
+++ b/SCons/Tool/tex.py
@@ -42,6 +42,7 @@ import SCons.Node
 import SCons.Node.FS
 import SCons.Util
 import SCons.Scanner.LaTeX
+from SCons.Util.sctypes import _null
 
 Verbose = False
 
@@ -143,9 +144,6 @@ MakeAcronymsAction = None
 
 # An action to run MakeIndex (for newglossary commands) on a file.
 MakeNewGlossaryAction = None
-
-# Used as a return value of modify_env_var if the variable is not set.
-_null = SCons.Scanner.LaTeX._null
 
 modify_env_var = SCons.Scanner.LaTeX.modify_env_var
 

--- a/SCons/Tool/xgettext.py
+++ b/SCons/Tool/xgettext.py
@@ -34,7 +34,6 @@ import SCons.Tool
 import SCons.Util
 import SCons.Warnings
 from SCons.Builder import BuilderBase
-from SCons.Environment import _null
 from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
 from SCons.Platform.mingw import MINGW_DEFAULT_PATHS
 from SCons.Tool.GettextCommon import (
@@ -44,6 +43,7 @@ from SCons.Tool.GettextCommon import (
     _xgettext_exists,
     # XgettextToolWarning,
 )
+from SCons.Util.sctypes import _null
 
 
 class _CmdRunner:

--- a/SCons/Util/sctypes.py
+++ b/SCons/Util/sctypes.py
@@ -132,11 +132,21 @@ def is_Scalar(  # pylint: disable=redefined-outer-name,redefined-builtin
     return isinstance(obj, StringTypes) or not isinstance(obj, Iterable)
 
 
+# Sentinels for use when None is needed for something else
+# 1. Simple:
+
+class _Null:
+    pass
+
+_null = _Null()
+
+# 2. More complex - when we don't necessarily want to check for the
+# sentinel, and don't want it to fail if used as the "real" class:
+
 # From Dinu C. Gherman,
 # Python Cookbook, second edition, recipe 6.17, p. 277.
 # Also: https://code.activestate.com/recipes/68205
 # ASPN: Python Cookbook: Null Object Design Pattern
-
 
 class Null:
     """Null objects always and reliably 'do nothing'."""
@@ -167,6 +177,9 @@ class Null:
     def __delattr__(self, name):
         return self
 
+# 3. Refining the previous, to add iteration capability.
+# You'd want to combine these two, but there are uses of _Null that
+# don't seem to work right with _NullSeq - a TODO
 
 class NullSeq(Null):
     """A Null object that can also be iterated over."""


### PR DESCRIPTION
Nit: instead of lots of places defining their own `_null` sentinel, put it in `Util` and let the code get it from there.

At some point will improve this sentinel to get better traceability (a repr with more information than use a memory address, for example) but for now the simple one is fine, just don't define the same thing locally in many places, or import it from Environment as some did - that carries danger of import loops.

There are no functional changes, so no updates to docs or tests.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
