### PR TITLE
MSVC: Remove 32-bit arm target and host from the VS 2026 configuration.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,9 +16,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Whatever John Doe did.
 
   From Joseph Brill:
-    - MSVC: Remove the 32-bit arm target and host from the Visual Studio 2026
-      configuration.  Visual Studio 2026 removed support for targeting arm. The
-      arm libraries are not included in the latest Windows SDK (10.0.26100.0).
+    - MSVC: Added a host/target batch file configuration table for Visual
+      Studio 2026.  Visual Studio 2026 removed support for 32-bit arm targets.
 
   From Thaddeus Crews:
     - Purge vim/emac local variable bloat.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
+  From Joseph Brill:
+    - MSVC: Remove the 32-bit arm target and host from the Visual Studio 2026
+      configuration.  Visual Studio 2026 removed support for targeting arm. The
+      arm libraries are not included in the latest Windows SDK (10.0.26100.0).
+
   From Thaddeus Crews:
     - Purge vim/emac local variable bloat.
     - Implement type hints for Node subclasses.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -36,11 +36,6 @@ FIXES
 
 - Fix --debug=includes for case of multiple source files.
 
-- MSVC: Remove the 32-bit arm target and host from the Visual Studio
-  2026 configuration. Visual Studio 2026 removed support for targeting
-  arm.  The arm libraries are not included in the latest Windows
-  SDK (10.0.26100.0).
-
 IMPROVEMENTS
 ------------
 
@@ -96,6 +91,8 @@ DEVELOPMENT
 - Docbook tests: improve skip message, more clearly indicate which test
   need actual installed system programs (add -live suffix).
 
+- MSVC: Added a host/target batch file configuration table for Visual
+  Studio 2026.  Visual Studio 2026 removed support for 32-bit arm targets.
 
 
 Thanks to the following contributors listed below for their contributions to this release.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -36,6 +36,11 @@ FIXES
 
 - Fix --debug=includes for case of multiple source files.
 
+- MSVC: Remove the 32-bit arm target and host from the Visual Studio
+  2026 configuration. Visual Studio 2026 removed support for targeting
+  arm.  The arm libraries are not included in the latest Windows
+  SDK (10.0.26100.0).
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Tool/MSCommon/README.rst
+++ b/SCons/Tool/MSCommon/README.rst
@@ -81,13 +81,13 @@ Legend:
 
   Develop
     devenv.com or msdev.com is detected.
-  
+
   Express
     WDExpress.exe or VCExpress.exe is detected.
-  
+
   BuildTools [VS2015]
     The vcvarsall batch file dispatches to the buildtools batch file.
-  
+
   CmdLine [VS2015]
     Neither Develop, Express, or BuildTools.
 
@@ -204,6 +204,23 @@ The following issues are known to exist:
   the default environment was moved from ``MSCommon/vc.py`` to ``MSCommon/MSVC/SetupEnvDefault.py``.
   There are very few, if any, existing unit tests. Now that the code is isolated in its own
   module with a limited API, unit tests may be easier to implement.
+
+
+Potential Issues
+================
+
+The following potential issues are known to exist:
+
+* Visual Studio 2026 removed support for 32-bit arm targets. The 32-bit arm libraries are not included
+  in the latest Windows SDK (10.0.26100.0).
+
+  The Visual Studio documentation states: "Developers needing to target ARM32 can continue using the
+  Visual Studio 2022 v143 build tools".
+
+  As of Visual Studio 2022 17.14.23, builds targeting 32-bit arm on a machine that has Windows SDK
+  10.0.26100.0 or later installed, may fail due to the Visual Studio 2022 batch file implementation.
+  If this happens, explicitly passing an earlier Windows SDK version via ``MSVC_SDK_VERSION`` may be
+  required.  For example, ``MSVC_SDK_VERSION="10.0.22621.0"``.
 
 
 Experimental Features

--- a/SCons/Tool/MSCommon/README.rst
+++ b/SCons/Tool/MSCommon/README.rst
@@ -81,13 +81,13 @@ Legend:
 
   Develop
     devenv.com or msdev.com is detected.
-
+  
   Express
     WDExpress.exe or VCExpress.exe is detected.
-
+  
   BuildTools [VS2015]
     The vcvarsall batch file dispatches to the buildtools batch file.
-
+  
   CmdLine [VS2015]
     Neither Develop, Express, or BuildTools.
 
@@ -204,23 +204,6 @@ The following issues are known to exist:
   the default environment was moved from ``MSCommon/vc.py`` to ``MSCommon/MSVC/SetupEnvDefault.py``.
   There are very few, if any, existing unit tests. Now that the code is isolated in its own
   module with a limited API, unit tests may be easier to implement.
-
-
-Potential Issues
-================
-
-The following potential issues are known to exist:
-
-* Visual Studio 2026 removed support for 32-bit arm targets. The 32-bit arm libraries are not included
-  in the latest Windows SDK (10.0.26100.0).
-
-  The Visual Studio documentation states: "Developers needing to target ARM32 can continue using the
-  Visual Studio 2022 v143 build tools".
-
-  As of Visual Studio 2022 17.14.23, builds targeting 32-bit arm on a machine that has Windows SDK
-  10.0.26100.0 or later installed, may fail due to the Visual Studio 2022 batch file implementation.
-  If this happens, explicitly passing an earlier Windows SDK version via ``MSVC_SDK_VERSION`` may be
-  required.  For example, ``MSVC_SDK_VERSION="10.0.22621.0"``.
 
 
 Experimental Features

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -47,7 +47,6 @@ from subprocess import PIPE
 import re
 from collections import (
     namedtuple,
-    OrderedDict,
 )
 import json
 from functools import cmp_to_key
@@ -325,11 +324,11 @@ _GE2026_HOST_TARGET_CFG = _host_target_config_factory(
 
     label = 'GE2026',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['amd64', 'x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['arm64', 'amd64', 'x86']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['amd64', 'x86'],
+        'x86':   ['x86'],
+        'arm64': ['arm64', 'amd64', 'x86'],
+    },
 
     host_all_targets = {
         'amd64': ['amd64', 'x86', 'arm64'],
@@ -349,7 +348,7 @@ _GE2026_HOST_TARGET_CFG = _host_target_config_factory(
 
 # 14.3 (VS2022)
 
-_LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
+_EQ2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
 
     ('amd64', 'amd64') : ('vcvars64.bat',          ('bin', 'Hostx64', 'x64')),
     ('amd64', 'x86')   : ('vcvarsamd64_x86.bat',   ('bin', 'Hostx64', 'x86')),
@@ -368,16 +367,16 @@ _LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
 
 }
 
-_LE2022_HOST_TARGET_CFG = _host_target_config_factory(
+_EQ2022_HOST_TARGET_CFG = _host_target_config_factory(
 
-    label = 'LE2022',
+    label = 'EQ2022',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['amd64', 'x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['arm64', 'amd64', 'x86']),
-        ('arm',   ['x86']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['amd64', 'x86'],
+        'x86':   ['x86'],
+        'arm64': ['arm64', 'amd64', 'x86'],
+        'arm':   ['x86'],
+    },
 
     host_all_targets = {
         'amd64': ['amd64', 'x86', 'arm64', 'arm'],
@@ -395,11 +394,11 @@ _LE2022_HOST_TARGET_CFG = _host_target_config_factory(
 
 )
 
-# debug("_LE2022_HOST_TARGET_CFG: %s", _LE2022_HOST_TARGET_CFG)
+# debug("_EQ2022_HOST_TARGET_CFG: %s", _EQ2022_HOST_TARGET_CFG)
 
 # 14.2 (VS2019) to 14.1 (VS2017)
 
-_LE2019_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
+_LE2019_GE2017_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
 
     ('amd64', 'amd64') : ('vcvars64.bat',          ('bin', 'Hostx64', 'x64')),
     ('amd64', 'x86')   : ('vcvarsamd64_x86.bat',   ('bin', 'Hostx64', 'x86')),
@@ -418,16 +417,16 @@ _LE2019_HOST_TARGET_BATCHFILE_CLPATHCOMPS = {
 
 }
 
-_LE2019_HOST_TARGET_CFG = _host_target_config_factory(
+_LE2019_GE2017_HOST_TARGET_CFG = _host_target_config_factory(
 
-    label = 'LE2019',
+    label = 'LE2019_GE2017',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['amd64', 'x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['amd64', 'x86']),
-        ('arm',   ['x86']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['amd64', 'x86'],
+        'x86':   ['x86'],
+        'arm64': ['amd64', 'x86'],
+        'arm':   ['x86'],
+    },
 
     host_all_targets = {
         'amd64': ['amd64', 'x86', 'arm64', 'arm'],
@@ -445,7 +444,7 @@ _LE2019_HOST_TARGET_CFG = _host_target_config_factory(
 
 )
 
-# debug("_LE2019_HOST_TARGET_CFG: %s", _LE2019_HOST_TARGET_CFG)
+# debug("_LE2019_GE2017_HOST_TARGET_CFG: %s", _LE2019_GE2017_HOST_TARGET_CFG)
 
 # 14.0 (VS2015) to 10.0 (VS2010)
 
@@ -456,7 +455,7 @@ _LE2019_HOST_TARGET_CFG = _host_target_config_factory(
 # bin directory (i.e., <VSROOT>/VC/bin).  Any other tools are in subdirectory
 # named for the the host/target pair or a single name if the host==target.
 
-_LE2015_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
+_LE2015_GE2010_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
 
     ('amd64', 'amd64') : ('amd64',     'vcvars64.bat',         ('bin', 'amd64')),
     ('amd64', 'x86')   : ('amd64_x86', 'vcvarsamd64_x86.bat',  ('bin', 'amd64_x86')),
@@ -476,17 +475,17 @@ _LE2015_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
 
 }
 
-_LE2015_HOST_TARGET_CFG = _host_target_config_factory(
+_LE2015_GE2010_HOST_TARGET_CFG = _host_target_config_factory(
 
-    label = 'LE2015',
+    label = 'LE2015_GE2010',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['amd64', 'x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['amd64', 'x86']),
-        ('arm',   ['arm']),
-        ('ia64',  ['ia64']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['amd64', 'x86'],
+        'x86':   ['x86'],
+        'arm64': ['amd64', 'x86'],
+        'arm':   ['arm'],
+        'ia64':  ['ia64'],
+    },
 
     host_all_targets = {
         'amd64': ['amd64', 'x86', 'arm'],
@@ -506,11 +505,11 @@ _LE2015_HOST_TARGET_CFG = _host_target_config_factory(
 
 )
 
-# debug("_LE2015_HOST_TARGET_CFG: %s", _LE2015_HOST_TARGET_CFG)
+# debug("_LE2015_GE2010_HOST_TARGET_CFG: %s", _LE2015_GE2010_HOST_TARGET_CFG)
 
 # 9.0 (VS2008) to 8.0 (VS2005)
 
-_LE2008_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
+_LE2008_GE2005_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
 
     ('amd64', 'amd64') : ('amd64',     'vcvarsamd64.bat',      ('bin', 'amd64')),
     ('amd64', 'x86') :   ('x86',       'vcvars32.bat',         ('bin', )),
@@ -526,16 +525,16 @@ _LE2008_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS = {
 
 }
 
-_LE2008_HOST_TARGET_CFG = _host_target_config_factory(
+_LE2008_GE2005_HOST_TARGET_CFG = _host_target_config_factory(
 
-    label = 'LE2008',
+    label = 'LE2008_GE2005',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['amd64', 'x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['amd64', 'x86']),
-        ('ia64',  ['ia64']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['amd64', 'x86'],
+        'x86':   ['x86'],
+        'arm64': ['amd64', 'x86'],
+        'ia64':  ['ia64'],
+    },
 
     host_all_targets = {
         'amd64': ['amd64', 'x86'],
@@ -553,7 +552,7 @@ _LE2008_HOST_TARGET_CFG = _host_target_config_factory(
 
 )
 
-# debug("_LE2008_HOST_TARGET_CFG: %s", _LE2008_HOST_TARGET_CFG)
+# debug("_LE2008_GE2005_HOST_TARGET_CFG: %s", _LE2008_GE2005_HOST_TARGET_CFG)
 
 # 7.1 (VS2003) and earlier
 
@@ -564,11 +563,11 @@ _LE2003_HOST_TARGET_CFG = _host_target_config_factory(
 
     label = 'LE2003',
 
-    host_all_hosts = OrderedDict([
-        ('amd64', ['x86']),
-        ('x86',   ['x86']),
-        ('arm64', ['x86']),
-    ]),
+    host_all_hosts = {
+        'amd64': ['x86'],
+        'x86':   ['x86'],
+        'arm64': ['x86'],
+    },
 
     host_all_targets = {
         'amd64': ['x86'],
@@ -668,16 +667,16 @@ def get_host_target(env, msvc_version, all_host_targets: bool=False):
         host_target_cfg = _GE2026_HOST_TARGET_CFG
     elif 145 > vernum_int >= 143:
         # 14.3 (VS2022)
-        host_target_cfg = _LE2022_HOST_TARGET_CFG
+        host_target_cfg = _EQ2022_HOST_TARGET_CFG
     elif 143 > vernum_int >= 141:
         # 14.2 (VS2019) to 14.1 (VS2017)
-        host_target_cfg = _LE2019_HOST_TARGET_CFG
+        host_target_cfg = _LE2019_GE2017_HOST_TARGET_CFG
     elif 141 > vernum_int >= 100:
         # 14.0 (VS2015) to 10.0 (VS2010)
-        host_target_cfg = _LE2015_HOST_TARGET_CFG
+        host_target_cfg = _LE2015_GE2010_HOST_TARGET_CFG
     elif 100 > vernum_int >= 80:
         # 9.0 (VS2008) to 8.0 (VS2005)
-        host_target_cfg = _LE2008_HOST_TARGET_CFG
+        host_target_cfg = _LE2008_GE2005_HOST_TARGET_CFG
     else: # 80 > vernum_int
         # 7.1 (VS2003) and earlier
         host_target_cfg = _LE2003_HOST_TARGET_CFG
@@ -1828,24 +1827,24 @@ def find_batch_file(msvc_version, host_arch, target_arch, pdir):
     elif 145 > vernum_int >= 143:
         # 14.3 (VS2022)
         batfiledir = os.path.join(pdir, "Auxiliary", "Build")
-        batfile, _ = _LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
+        batfile, _ = _EQ2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
         batfilename = os.path.join(batfiledir, batfile)
         vcdir = pdir
     elif 143 > vernum_int >= 141:
         # 14.2 (VS2019) to 14.1 (VS2017)
         batfiledir = os.path.join(pdir, "Auxiliary", "Build")
-        batfile, _ = _LE2019_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
+        batfile, _ = _LE2019_GE2017_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
         batfilename = os.path.join(batfiledir, batfile)
         vcdir = pdir
     elif 141 > vernum_int >= 100:
         # 14.0 (VS2015) to 10.0 (VS2010)
-        arg, batfile, cl_path_comps = _LE2015_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
+        arg, batfile, cl_path_comps = _LE2015_GE2010_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
         batfilename = os.path.join(pdir, "vcvarsall.bat")
         depbat = os.path.join(pdir, *cl_path_comps, batfile)
         clexe = os.path.join(pdir, *cl_path_comps, _CL_EXE_NAME)
     elif 100 > vernum_int >= 80:
         # 9.0 (VS2008) to 8.0 (VS2005)
-        arg, batfile, cl_path_comps = _LE2008_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
+        arg, batfile, cl_path_comps = _LE2008_GE2005_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host_arch, target_arch)]
         if vernum_int == 90 and MSVC.Kind.msvc_version_is_vcforpython(msvc_version):
             # 9.0 (VS2008) Visual C++ for Python:
             #     sdk batch files do not point to the VCForPython installation
@@ -1962,10 +1961,10 @@ def _check_files_exist_in_vc_dir(env, vc_dir, msvc_version) -> bool:
             host_target_batchfile_clpathcomps = _GE2026_HOST_TARGET_BATCHFILE_CLPATHCOMPS
         elif 145 > vernum_int >= 143:
             # 14.3 (VS2022)
-            host_target_batchfile_clpathcomps = _LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS
+            host_target_batchfile_clpathcomps = _EQ2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS
         else:
             # 14.2 (VS2019) to 14.1 (VS2017)
-            host_target_batchfile_clpathcomps = _LE2019_HOST_TARGET_BATCHFILE_CLPATHCOMPS
+            host_target_batchfile_clpathcomps = _LE2019_GE2017_HOST_TARGET_BATCHFILE_CLPATHCOMPS
 
         for host_platform, target_platform in host_target_list:
 
@@ -1996,10 +1995,10 @@ def _check_files_exist_in_vc_dir(env, vc_dir, msvc_version) -> bool:
 
         if vernum_int >= 100:
             # 14.0 (VS2015) to 10.0 (VS2010)
-            host_target_batcharg_batchfile_clpathcomps = _LE2015_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS
+            host_target_batcharg_batchfile_clpathcomps = _LE2015_GE2010_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS
         else:
             # 9.0 (VS2008) to 8.0 (VS2005)
-            host_target_batcharg_batchfile_clpathcomps = _LE2008_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS
+            host_target_batcharg_batchfile_clpathcomps = _LE2008_GE2005_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS
 
         if vernum_int == 90 and MSVC.Kind.msvc_version_is_vcforpython(msvc_version):
             # 9.0 (VS2008) Visual C++ for Python:

--- a/SCons/Tool/MSCommon/vcTests.py
+++ b/SCons/Tool/MSCommon/vcTests.py
@@ -149,9 +149,9 @@ class MSVcTestCase(unittest.TestCase):
             self.assertTrue(result, "Checking host: %s target: %s" % (host, target))
 
         # Test 14.3 (VS2022)
-        vc_le2022_list = SCons.Tool.MSCommon.vc._LE2022_HOST_TARGET_CFG.all_pairs
-        for host, target in vc_le2022_list:
-            batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
+        vc_eq2022_list = SCons.Tool.MSCommon.vc._EQ2022_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_eq2022_list:
+            batfile, clpathcomps = SCons.Tool.MSCommon.vc._EQ2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
             # print("GE 14.3 Got: (%s, %s) -> (%s, %s)"%(host,target,batfile,clpathcomps))
 
             env={'TARGET_ARCH':target, 'HOST_ARCH':host}
@@ -164,9 +164,9 @@ class MSVcTestCase(unittest.TestCase):
             self.assertTrue(result, "Checking host: %s target: %s" % (host, target))
 
         # Test 14.2 (VS2019) to 14.1 (VS2017) versions
-        vc_le2019_list = SCons.Tool.MSCommon.vc._LE2019_HOST_TARGET_CFG.all_pairs
-        for host, target in vc_le2019_list:
-            batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2019_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
+        vc_le2019_ge2017_list = SCons.Tool.MSCommon.vc._LE2019_GE2017_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_le2019_ge2017_list:
+            batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2019_GE2017_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
             # print("LE 14.2 Got: (%s, %s) -> (%s, %s)"%(host,target,batfile,clpathcomps))
 
             env={'TARGET_ARCH':target, 'HOST_ARCH':host}
@@ -177,9 +177,9 @@ class MSVcTestCase(unittest.TestCase):
             self.assertTrue(result, "Checking host: %s target: %s" % (host, target))
 
         # Test 14.0 (VS2015) to 10.0 (VS2010) versions
-        vc_le2015_list = SCons.Tool.MSCommon.vc._LE2015_HOST_TARGET_CFG.all_pairs
-        for host, target in vc_le2015_list:
-            batarg, batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2015_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host, target)]
+        vc_le2015_ge2010_list = SCons.Tool.MSCommon.vc._LE2015_GE2010_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_le2015_ge2010_list:
+            batarg, batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2015_GE2010_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host, target)]
             # print("LE 14.0 Got: (%s, %s) -> (%s, %s, %s)"%(host,target,batarg,batfile,clpathcomps))
             env={'TARGET_ARCH':target, 'HOST_ARCH':host}
             MSVcTestCase._createDummyFile('.', 'vcvarsall.bat', add_bin=False)
@@ -191,9 +191,9 @@ class MSVcTestCase(unittest.TestCase):
             self.assertTrue(result, "Checking host: %s target: %s" % (host, target))
 
         # Test 9.0 (VC2008) to 8.0 (VS2005)
-        vc_le2008_list = SCons.Tool.MSCommon.vc._LE2008_HOST_TARGET_CFG.all_pairs
-        for host, target in vc_le2008_list:
-            batarg, batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2008_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host, target)]
+        vc_le2008_ge2005_list = SCons.Tool.MSCommon.vc._LE2008_GE2005_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_le2008_ge2005_list:
+            batarg, batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2008_GE2005_HOST_TARGET_BATCHARG_BATCHFILE_CLPATHCOMPS[(host, target)]
             # print("LE 9.0 Got: (%s, %s) -> (%s, %s, %s)"%(host,target,batarg,batfile,clpathcomps))
             env={'TARGET_ARCH':target, 'HOST_ARCH':host}
             MSVcTestCase._createDummyFile('.', 'vcvarsall.bat', add_bin=False)

--- a/SCons/Tool/MSCommon/vcTests.py
+++ b/SCons/Tool/MSCommon/vcTests.py
@@ -133,10 +133,25 @@ class MSVcTestCase(unittest.TestCase):
         except IOError as e:
             print("Failed trying to write :%s :%s" % (tools_version_file, e))
 
-        # Test 14.3 (VS2022) and later
-        vc_ge2022_list = SCons.Tool.MSCommon.vc._GE2022_HOST_TARGET_CFG.all_pairs
-        for host, target in vc_ge2022_list:
-            batfile, clpathcomps = SCons.Tool.MSCommon.vc._GE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
+        # Test 14.5 (VS2026) and later
+        vc_ge2026_list = SCons.Tool.MSCommon.vc._GE2026_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_ge2026_list:
+            batfile, clpathcomps = SCons.Tool.MSCommon.vc._GE2026_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
+            # print("GE 14.5 Got: (%s, %s) -> (%s, %s)"%(host,target,batfile,clpathcomps))
+
+            env={'TARGET_ARCH':target, 'HOST_ARCH':host}
+            path = os.path.join('.', "Auxiliary", "Build", batfile)
+            MSVcTestCase._createDummyFile(path, batfile, add_bin=False)
+            path = os.path.join('.', 'Tools', 'MSVC', MS_TOOLS_VERSION, *clpathcomps)
+            MSVcTestCase._createDummyFile(path, 'cl.exe', add_bin=False)
+            result=check(env, '.', '14.5')
+            # print("for:(%s, %s) got :%s"%(host, target, result))
+            self.assertTrue(result, "Checking host: %s target: %s" % (host, target))
+
+        # Test 14.3 (VS2022)
+        vc_le2022_list = SCons.Tool.MSCommon.vc._LE2022_HOST_TARGET_CFG.all_pairs
+        for host, target in vc_le2022_list:
+            batfile, clpathcomps = SCons.Tool.MSCommon.vc._LE2022_HOST_TARGET_BATCHFILE_CLPATHCOMPS[(host,target)]
             # print("GE 14.3 Got: (%s, %s) -> (%s, %s)"%(host,target,batfile,clpathcomps))
 
             env={'TARGET_ARCH':target, 'HOST_ARCH':host}

--- a/test/MSVC/MSVC_UWP_APP.py
+++ b/test/MSVC/MSVC_UWP_APP.py
@@ -31,7 +31,6 @@ import re
 
 from SCons.Tool.MSCommon.vc import get_installed_vcs_components
 from SCons.Tool.MSCommon.vc import get_native_host_platform
-from SCons.Tool.MSCommon.vc import _GE2022_HOST_TARGET_CFG
 from SCons.Tool.MSCommon.MSVC.Kind import (
     msvc_version_is_express,
     msvc_version_is_btdispatch,


### PR DESCRIPTION
Changes:
* MSVC: Remove the 32-bit arm target and host from the Visual Studio 2026 configuration.  Visual Studio 2026 removed support for targeting arm. The arm libraries are not included in the latest Windows SDK (10.0.26100.0).
* Document the potential issue with targeting 32-bit arm using Visual Studio 2022 and Windows SDK 10.0.26100 or later is installed in `SCons/Tool/MSCommon/README.rst`.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
