### PR TITLE
Updates for mailing list change

### DIFF
--- a/README-SF.rst
+++ b/README-SF.rst
@@ -41,7 +41,7 @@ Latest Version
 Before going further, you can check that the package you have is the latest
 version at the SCons download page:
 
-        http://www.scons.org/pages/download.html
+        https://scons.org/pages/download.html
 
 
 Execution Requirements
@@ -448,7 +448,7 @@ bootstrap.py
 debian/
     Files needed to construct a Debian package. The contents of this directory
     are dictated by the Debian Policy Manual
-    (http://www.debian.org/doc/debian-policy). The package will not be
+    (https://www.debian.org/doc/debian-policy). The package will not be
     accepted into the Debian distribution unless the contents of this
     directory satisfy the relevant Debian policies.
 
@@ -513,7 +513,7 @@ section of small examples for getting started using SCons.
 
 Additional documentation for SCons is available at:
 
-        http://www.scons.org/documentation.html
+        https://scons.org/documentation.html
 
 
 Licensing
@@ -531,7 +531,7 @@ The SCons project welcomes bug reports and feature requests.
 Please make sure you send email with the problem or feature request to
 the SCons users mailing list, which you can join via the link below:
 
-        http://two.pairlist.net/mailman/listinfo/scons-users
+        https://mail.python.org/mailman3/lists/scons-users.python.org
 
 Once you have discussed your issue on the users mailing list and the
 community has confirmed that it is either a new bug or a duplicate of an
@@ -551,11 +551,11 @@ In addition to the scons-users list which is appropriate for almost any
 question, there is a mailing list specifically for developers of SCons
 You may send questions or comments to the list at:
 
-        scons-dev@scons.org
+        scons-dev@python.org
 
 You may subscribe to the developer's mailing list using form on this page:
 
-        http://two.pairlist.net/mailman/listinfo/scons-dev
+        https://mail.python.org/mailman3/lists/scons-dev.python.org
 
 Subscription to the developer's mailing list is by approval.  In practice, no
 one is refused list membership, but we reserve the right to limit membership
@@ -573,13 +573,8 @@ Donations
 
 If you find SCons helpful, please consider making a donation (of cash,
 software, or hardware) to support continued work on the project.  Information
-is available at:
-
-        http://www.scons.org/donate.html
-
-or
-
-GitHub Sponsors button on https://github.com/scons/scons
+is available at https://scons.org/donate.html
+or use the GitHub Sponsors button on https://github.com/scons/scons
 
 
 For More Information
@@ -587,7 +582,7 @@ For More Information
 
 Check the SCons web site at:
 
-        http://www.scons.org/
+        https://scons.org/
 
 
 Author Info

--- a/README-local
+++ b/README-local
@@ -143,7 +143,7 @@ package:
 
 Additional documentation for SCons is available at:
 
-        http://www.scons.org/doc.html
+        https://www.scons.org/doc.html
 
 
 LICENSING
@@ -159,7 +159,7 @@ an approved Open Source license, which means:
 More information about OSI certifications and Open Source software is
 available at:
 
-        http://www.opensource.org/
+        https://www.opensource.org
 
 
 REPORTING BUGS
@@ -170,7 +170,7 @@ The SCons project welcomes bug reports and feature requests.
 Please make sure you send email with the problem or feature request to
 the SCons users mailing list, which you can join via the link below:
 
-        http://two.pairlist.net/mailman/listinfo/scons-users
+        https://mail.python.org/mailman3/lists/scons-users.python.org
 
 Once you have discussed your issue on the users mailing list and the
 community has confirmed that it is either a new bug or a duplicate of an
@@ -190,21 +190,21 @@ MAILING LISTS
 A mailing list for users of SCons is available.  You may send questions
 or comments to the list at:
 
-        scons-users@scons.org
+        scons-users@python.org
 
 You may subscribe to the scons-users mailing list at:
 
-        http://two.pairlist.net/mailman/listinfo/scons-users
+        https://mail.python.org/mailman3/lists/scons-users.python.org
 
 In addition to the scons-users list which is appropriate for almost any
 question, there is a mailing list specifically for developers of SCons
 You may send questions or comments to the list at:
 
-        scons-dev@scons.org
+        scons-dev@python.org
 
 You may subscribe to the developer's mailing list using form on this page:
 
-        http://two.pairlist.net/mailman/listinfo/scons-dev
+        https://mail.python.org/mailman3/lists/scons-dev.python.org
 
 Subscription to the developer's mailing list is by approval.  In practice, no
 one is refused list membership, but we reserve the right to limit membership
@@ -222,7 +222,7 @@ FOR MORE INFORMATION
 
 Check the SCons web site at:
 
-        http://www.scons.org/
+        https://scons.org
 
 
 Author Info

--- a/README-package.rst
+++ b/README-package.rst
@@ -74,7 +74,7 @@ Documentation
 =============
 
 Documentation for SCons is available at
-http://www.scons.org/documentation.html.
+https://scons.org/documentation.html.
 
 
 Execution Requirements
@@ -144,7 +144,7 @@ The SCons project welcomes bug reports and feature requests.
 
 Please make sure you send email with the problem or feature request to
 the SCons users mailing list, which you can join at
-https://two.pairlist.net/mailman/listinfo/scons-users,
+https://mail.python.org/mailman3/lists/scons-users.python.org,
 or on the SCons Discord server in
 `#scons-help <https://discord.gg/bXVpWAy#scons-help>`_.
 
@@ -166,7 +166,7 @@ question, there is a mailing list specifically for developers of SCons
 You may send questions or comments to the list at:
 
 You may subscribe to the developer's mailing list using the form at
-https://two.pairlist.net/mailman/listinfo/scons-dev.
+https://mail.python.org/mailman3/lists/scons-dev.python.org.
 
 Subscription to the developer's mailing list is by approval.  In practice, no
 one is refused list membership, but we reserve the right to limit membership
@@ -191,7 +191,7 @@ or the GitHub Sponsors button on https://github.com/scons/scons.
 For More Information
 ====================
 
-Check the SCons web site at https://www.scons.org/
+Check the SCons web site at https://scons.org
 
 
 Copyright (c) 2001 - 2024 The SCons Foundation

--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,7 @@ Features:
 Documentation
 =============
 
-Documentation for SCons is available at
-http://www.scons.org/documentation.html.
+See the `SCons documentation page <https://scons.org/documentation.html>`_.
 
 
 Latest Version
@@ -92,7 +91,7 @@ The last release to support Python 3.5 was 4.2.0.
 
 Some experimental features may require additional Python packages
 to be installed - at the moment the Ninja feature requires the
-supporting `ninja package <https://pypi.org/project/ninja/>`_.
+supporting `ninja package <https://pypi.org/project/ninja>`_.
 
 The default SCons configuration assumes use of the Microsoft Visual C++
 compiler suite on Win32 systems, and assumes a C compiler named ``cc``, a C++
@@ -124,10 +123,10 @@ Installation
 ============
 
 The preferred way to install SCons is through the Python installer, ``pip``
-(or equivalent alternatives, such as the Anaconda installer, ``conda``).
+(or equivalent alternatives, such as ``uv`` or the Anaconda installer, ``conda``).
 You can install either from a wheel package or from the source directory.
-To work on a project that builds using SCons, installation lets you
-just use ``scons`` as a command and not worry about things.  In this
+To work on a project that builds using SCons, installating lets you
+just use ``scons`` as a command and not worry about paths.  In this
 case, we usually suggest using a virtualenv, to isolate the Python
 environment to that project
 (some notes on that:
@@ -154,7 +153,7 @@ Some installation examples::
 Note that on Windows, SCons installed via ``pip`` puts an executable
 ``scons.exe`` in the script directory of the Python installation,
 or in a shadow script directory if you did a User Install.
-To run ``scons`` as a command, you'll need this in your search path.
+To run ``scons`` as a command, you'll need this directory in your search path.
 
 Fortunately, ``pip`` will warn you about this - pay attention to any
 messages during installation like this::
@@ -168,9 +167,9 @@ messages during installation like this::
 If you are running on a system which uses a package manager
 (for example most Linux distributions), you may, at your option,
 use the package manager (e.g. ``apt``, ``dnf``, ``yum``,
-``zypper``, ``brew``, ``pacman`` etc.) to install a version
-of SCons.  Some distributions keep up to date with SCons releases
-very quickly, while others may delay, so the version of SCons
+``zypper``, ``brew``, ``pacman`` etc.) to install a system-wide version
+of SCons.  Some distributions keep up to date with SCons releases,
+while others may delay, so the version of SCons
 you want to run may factor into your choice.
 
 
@@ -202,7 +201,7 @@ The SCons project welcomes bug reports and feature requests.
 
 Please make sure you send email with the problem or feature request to
 the SCons users mailing list, which you can join at
-https://two.pairlist.net/mailman/listinfo/scons-users,
+https://mail.python.org/mailman3/lists/scons-users.python.org/,
 or on the SCons Discord server in
 `#scons-help <https://discord.gg/bXVpWAy#scons-help>`_.
 
@@ -221,8 +220,9 @@ Bug-fix Policy
 
 At this time, the application of bug-fix pull requests *normally* happens
 at the head of the main branch. In other words fixes are likely to appear
-in the next regular release and there probably won't be a bugfix update
-to a past release.  Consumers are of course free to internally maintain
+in a bugfix to the current release or in the next regular release
+and there probably won't be a bugfix update to older releases.
+Consumers are of course free to internally maintain
 releases on their own by taking submitted patches and applying them.
 
 
@@ -231,11 +231,11 @@ Mailing Lists and Other Contacts
 
 In addition to the scons-users list, an active mailing list for developers
 of SCons is available.  You may send questions or comments to the list
-at scons-dev@scons.org.
+at scons-dev@python.org.
 
 You may subscribe to the developer's mailing list using the form at
-https://two.pairlist.net/mailman/listinfo/scons-dev.  The same page
-contains archives of past postings.
+https://mail.python.org/mailman3/lists/scons-dev.python.org.
+The same page contains archives of past postings.
 
 Subscription to the developer's mailing list is by approval.  In practice, no
 one is refused list membership, but we reserve the right to limit membership
@@ -250,7 +250,7 @@ https://scons.org/contact.html.
 Reproducible Builds
 ===================
 SCons itself is set up to do "reproducible builds"
-(see (https://reproducible-builds.org/specs/source-date-epoch/)
+(see (https://reproducible-builds.org/specs/source-date-epoch)
 if environment variables ``SOURCE_DATE_EPOCH`` is set - that is,
 fields in the package which could change each time the package is
 constructed are forced to constant values.
@@ -265,14 +265,14 @@ Donations
 =========
 
 If you find SCons helpful, please consider making a donation (of cash,
-software, or hardware) to support continued work on the project.  Information
-is available at https://www.scons.org/donate.html
-or the GitHub Sponsors button on https://github.com/scons/scons.
+software, or hardware) to support continued work on the project.
+See `Donation information <https://scons.org/donate.html>`_
+or the `GitHub Sponsors button <https://github.com/scons/scons>`_.
 
 For More Information
 ====================
 
-Check the SCons web site at https://www.scons.org/
+Check the `SCons web site <https://scons.org>`_.
 
 
 Author Info

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Installation
 The preferred way to install SCons is through the Python installer, ``pip``
 (or equivalent alternatives, such as ``uv`` or the Anaconda installer, ``conda``).
 You can install either from a wheel package or from the source directory.
-To work on a project that builds using SCons, installating lets you
+To work on a project that builds using SCons, "installing" lets you
 just use ``scons`` as a command and not worry about paths.  In this
 case, we usually suggest using a virtualenv, to isolate the Python
 environment to that project

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1155,7 +1155,7 @@ def _main(parser):
         msg = (
             f"Support for Python older than {deprecated_version_string}"
             f" is deprecated ({python_version_string()} detected).\n"
-            "    If this will cause hardship, contact scons-dev@scons.org"
+            "    If this will cause hardship, contact scons-dev@python.org"
         )
         SCons.Warnings.warn(SCons.Warnings.PythonVersionWarning, msg)
 

--- a/SCons/Tool/docbook/docs/manual.xml
+++ b/SCons/Tool/docbook/docs/manual.xml
@@ -244,7 +244,7 @@ with large input files may occur. There will definitely arise the need for
 adding features, or a variable. Let us know if you can think of a nice
 improvement or have worked on a bugfix/patch with success. Enter your issues at the
 Launchpad bug tracker for the Docbook Tool, or write to the User General Discussion
-list of SCons at <literal>scons-users@scons.org</literal>.
+list of SCons at <email>scons-users@python.org</email>.
 </para>
 </section>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -9175,7 +9175,7 @@ where multiple Qt installations are possible.</para>
     and Anthony Roach <email>aroach@electriceyeball.com</email>.
   </para>
   <para>
-    Since 2010: The SCons Development Team <email>scons-dev@scons.org</email>.
+    Since 2010: The SCons Development Team <email>scons-dev@python.org</email>.
   </para>
 </refsect1>
 </refentry>

--- a/doc/man/sconsign.xml
+++ b/doc/man/sconsign.xml
@@ -319,7 +319,7 @@ on GitHub</ulink>.
 <para>Originally: Steven Knight <email>knight@baldmt.com</email>
   and Anthony Roach <email>aroach@electriceyeball.com</email>.</para>
   <para>
-Since 2010: The SCons Development Team <email>scons-dev@scons.org</email>.
+Since 2010: The SCons Development Team <email>scons-dev@python.org</email>.
 </para>
 </refsect1>
 </refentry>

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -513,8 +513,8 @@ This file is processed by the bin/SConsDoc.py module.
 
 <!-- Mailing lists -->
 
-<!ENTITY scons-devel "<email xmlns='http://www.scons.org/dbxsd/v1.0'>scons-dev@scons.org</email>">
-<!ENTITY scons-users "<email xmlns='http://www.scons.org/dbxsd/v1.0'>scons-users@scons.org</email>">
+<!ENTITY scons-devel "<email xmlns='http://www.scons.org/dbxsd/v1.0'>scons-dev@python.org</email>">
+<!ENTITY scons-users "<email xmlns='http://www.scons.org/dbxsd/v1.0'>scons-users@python.org</email>">
 
 
 <!-- Character entities -->

--- a/doc/user/external.xml
+++ b/doc/user/external.xml
@@ -359,9 +359,12 @@ conda install -c conda-forge ninja
         </para>
 
         <para>
-            It is not expected that the &b-link-Ninja; builder will work for all builds at this point. It is still under active
-            development. If you find that your build doesn't work with &ninja; please bring this to the <ulink url="https://pairlist4.pair.net/mailman/listinfo/scons-users">users mailing list</ulink>
-            or <ulink url="https://discord.gg/bXVpWAy">
+            As an experimental feature, the &b-link-Ninja; builder may not
+            work for all builds at this point, and it remains in development.
+            . If you find that your build doesn't work with &ninja; please
+            bring this to the
+            <ulink url="https://mail.python.org/mailman3/lists/scons-users.python.org">users mailing list</ulink>
+            or the <ulink url="https://discord.gg/bXVpWAy">
             <literal>#scons-help</literal>
             </ulink> channel on our Discord server.
         </para>

--- a/packaging/rpm/scons.spec.in
+++ b/packaging/rpm/scons.spec.in
@@ -14,8 +14,8 @@ Group: Development/Tools
 BuildRoot: %{_tmppath}/%{name}-buildroot
 Prefix: %{_prefix}
 BuildArchitectures: noarch
-Vendor: The SCons Development Team <scons-dev@scons.org>
-Packager: The SCons Development Team <scons-dev@scons.org>
+Vendor: The SCons Development Team <scons-dev@python.org>
+Packager: The SCons Development Team <scons-dev@python.org>
 Requires: python >= 2.4
 Url: http://www.scons.org/
 

--- a/test/Removed/SourceCode/Old/SourceCode.py
+++ b/test/Removed/SourceCode/Old/SourceCode.py
@@ -38,7 +38,7 @@ SourceCode('.', None)
 """)
 
 msg = """SourceCode() has been deprecated and there is no replacement.
-\tIf you need this function, please contact scons-dev@scons.org"""
+\tIf you need this function, please contact scons-dev@python.org"""
 warning = test.deprecated_warning('deprecated-source-code', msg)
 
 test.subdir('sub', 'sub2')

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -192,7 +192,7 @@ def deprecated_python_version(version=sys.version_info):
 if deprecated_python_version():
     msg = r"""
 scons: warning: Support for Python older than %s is deprecated (%s detected).
-    If this will cause hardship, contact scons-dev@scons.org
+    If this will cause hardship, contact scons-dev@python.org
 """
     deprecated_python_expr = (
         re_escape(msg % (python_version_supported_str, python_version_string()))


### PR DESCRIPTION
The recent change of mailing list host, which changed both the address to send mail to and the administrative URL, is reflected in the codebase - mainly to the various README files, but also a number of one-off references.

This is only visible in the SCons code error messages emitted if a deprecated Python version is used, and in the metadata if an rpm package is generated - neither are "functional" changes.