### PR TITLE
Remove Python 3.7 & 3.8 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ environment:
   SCONS_CACHE_MSVC_CONFIG: "true"
   matrix:
     # Test oldest and newest supported Pythons, and a subset in between.
-    # Skipping 3.8, 3.10, 3.12 at this time
+    # Skipping 3.10, 3.12 at this time
     - WINPYTHON: "Python313"
     - WINPYTHON: "Python311"
     - WINPYTHON: "Python39"
@@ -45,7 +45,7 @@ environment:
 # to fine tune the number and platforms tested
 matrix:
   exclude:
-    # test python 3.7 on Visual Studio 2017 image
+    # test python 3.8 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python313"
     - image: Visual Studio 2017
@@ -59,13 +59,13 @@ matrix:
     - image: Visual Studio 2019
       WINPYTHON: "Python311"
     - image: Visual Studio 2019
-      WINPYTHON: "Python37"
+      WINPYTHON: "Python38"
 
     # test python 3.11, 3.13 on Visual Studio 2022 image
     - image: Visual Studio 2022
       WINPYTHON: "Python39"
     - image: Visual Studio 2022
-      WINPYTHON: "Python37"
+      WINPYTHON: "Python38"
 
 # Remove some binaries we don't want to be found
 # Note this is no longer needed, git-windows bin/ is quite minimal now.

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: [
-          {os: 'ubuntu-22.04', py: '3.7'},
+          {os: 'ubuntu-22.04', py: '3.9'},
           {os: 'ubuntu-24.04', py: '3.13'},
         ]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ SCons is an open-source software construction tool (build tool) implemented in P
 ## Building and Running
 
 ### Prerequisites
-*   Python 3.7 or higher.
+*   Python 3.9 or higher.
 *   Development dependencies: `python -m pip install -r requirements-dev.txt`
 
 ### Running SCons (Development)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,6 @@ python -m mypy SCons/               # type check
 - Git commits signed off (`git commit -s`). Add `Assisted-by:` to message for AI-generated changes.
 - Version in `SCons/__init__.py` (`__version__`) - automatically generated, do not edit.
 - CI: GitHub Actions (`runtest.yml` - test suite; `scons-package.yml` — packaging), AppVeyor (Windows, legacy).
-- Python >= 3.7 required.
+- Python >= 3.9 required.
 - Config log for `Configure()` lives at `config.log` in the build dir.
 - `.sconsign.dblite` persists across builds; deleting build dirs from disk doesn't clear sconsign entries.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ NOTE: The last release to support Python 3.7 or Python 3.8 is 4.11.0.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Thaddeus Crews:
+    - Removed Python 3.7 & 3.8 support.
+
   From Mats Wichmann:
     - Undo, for now, the 4.11.0 change (from PR 4875) to read a
       saved-Variables file using a File node. There were unanticipated

--- a/README-SF.rst
+++ b/README-SF.rst
@@ -47,7 +47,7 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.7 or higher. There should be no other
+Running SCons requires Python 3.9 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
 The last release to support Python 3.7 or Python 3.8 is 4.11.0.
@@ -613,4 +613,3 @@ many contributors, including but not at all limited to:
 \... and many others.
 
 Copyright (c) 2001 - 2026 The SCons Foundation
-

--- a/README-local
+++ b/README-local
@@ -43,7 +43,7 @@ scons-local package, or any SCons package, at the SCons download page:
 EXECUTION REQUIREMENTS
 ======================
 
-Running SCons requires Python 3.7 or higher. There should be no other
+Running SCons requires Python 3.9 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
 The last release to support Python 3.7 or Python 3.8 is 4.11.0.

--- a/README-package.rst
+++ b/README-package.rst
@@ -80,7 +80,7 @@ https://scons.org/documentation.html.
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.7 or higher. There should be no other
+Running SCons requires Python 3.9 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
 The last release to support Python 3.7 or Python 3.8 is 4.11.0.
@@ -196,4 +196,3 @@ Check the SCons web site at https://scons.org
 
 
 Copyright (c) 2001 - 2026 The SCons Foundation
-

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ is the latest version at the
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.7 or higher. There should be no other
+Running SCons requires Python 3.9 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
 The last release to support Python 3.7 or Python 3.8 is 4.11.0.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -23,6 +23,13 @@ DEPRECATED FUNCTIONALITY
 
 - List anything that's been deprecated since the last release
 
+REMOVED FUNCTIONALITY
+------------------------
+
+- List anything that's been outright removed since the last release
+
+- Removed Python 3.7 & 3.8 support.
+
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 

--- a/ReleaseConfig
+++ b/ReleaseConfig
@@ -37,7 +37,7 @@ version_tuple = (4, 10, 2, 'a', 0)
 # when that version is used.  Python versions prior to deprecate_python_version
 # cause a warning to be issued (assuming it's not disabled).  These values are
 # mandatory and must be present in the configuration file.
-unsupported_python_version = (3, 7, 0)
+unsupported_python_version = (3, 9, 0)
 deprecated_python_version = (3, 9, 0)
 
 # If release_date is (yyyy, mm, dd, hh, mm, ss), that is used as the release

--- a/ReleaseConfig
+++ b/ReleaseConfig
@@ -37,7 +37,7 @@ version_tuple = (4, 12, 0, 'a', 0)
 # when that version is used.  Python versions prior to deprecate_python_version
 # cause a warning to be issued (assuming it's not disabled).  These values are
 # mandatory and must be present in the configuration file.
-unsupported_python_version = (3, 7, 0)
+unsupported_python_version = (3, 9, 0)
 deprecated_python_version = (3, 9, 0)
 
 # If release_date is (yyyy, mm, dd, hh, mm, ss), that is used as the release

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1549,8 +1549,6 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1730,8 +1728,6 @@ class FunctionActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1742,8 +1738,6 @@ class FunctionActionTestCase(unittest.TestCase):
         }
 
         meth_matches = {
-            (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1983,8 +1977,6 @@ class LazyActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -2046,8 +2038,6 @@ class ActionCallerTestCase(unittest.TestCase):
             pass
 
         matches = {
-            (3, 7): b'd\x00S\x00',
-            (3, 8): b'd\x00S\x00',
             (3, 9): b'd\x00S\x00',
             (3, 10): b'd\x00S\x00',
             (3, 11): b'\x97\x00d\x00S\x00',
@@ -2249,8 +2239,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # we need different expected results per version
         # Note unlike the others, this result is a tuple, use assertIn
         expected = {
-            (3, 7): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
-            (3, 8): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
             (3, 9): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
             (3, 10): (  # 3.10.1, 3.10.2
                 bytearray(b"3, 3, 0, 0,(N.),(),(|\x00S\x00),(),()"),
@@ -2277,12 +2265,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # Since the python bytecode has per version differences,
         # we need different expected results per version
         expected = {
-            (3, 7): bytearray(
-                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
-            ),
-            (3, 8): bytearray(
-                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
-            ),
             (3, 9): bytearray(
                 b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
             ),
@@ -2312,12 +2294,6 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (3, 7): bytearray(
-                b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
-            ),
-            (3, 8): bytearray(
-                b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
-            ),
             (3, 9): bytearray(
                 b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
             ),

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1553,8 +1553,6 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1735,8 +1733,6 @@ class FunctionActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1748,8 +1744,6 @@ class FunctionActionTestCase(unittest.TestCase):
         }
 
         meth_matches = {
-            (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -1991,8 +1985,6 @@ class LazyActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
-            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
@@ -2055,8 +2047,6 @@ class ActionCallerTestCase(unittest.TestCase):
             pass
 
         matches = {
-            (3, 7): b'd\x00S\x00',
-            (3, 8): b'd\x00S\x00',
             (3, 9): b'd\x00S\x00',
             (3, 10): b'd\x00S\x00',
             (3, 11): b'\x97\x00d\x00S\x00',
@@ -2259,8 +2249,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # we need different expected results per version
         # Note unlike the others, this result is a tuple, use assertIn
         expected = {
-            (3, 7): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
-            (3, 8): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
             (3, 9): (bytearray(b"3, 3, 0, 0,(),(),(|\x00S\x00),(),()"),),
             (3, 10): (  # 3.10.1, 3.10.2
                 bytearray(b"3, 3, 0, 0,(N.),(),(|\x00S\x00),(),()"),
@@ -2288,12 +2276,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # Since the python bytecode has per version differences,
         # we need different expected results per version
         expected = {
-            (3, 7): bytearray(
-                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
-            ),
-            (3, 8): bytearray(
-                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
-            ),
             (3, 9): bytearray(
                 b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
             ),
@@ -2326,12 +2308,6 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (3, 7): bytearray(
-                b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
-            ),
-            (3, 8): bytearray(
-                b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
-            ),
             (3, 9): bytearray(
                 b"0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)"
             ),

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -210,44 +210,22 @@ class CacheDir:
             return False
 
         try:
-            # TODO: Python 3.7. See comment below.
-            # tempdir = tempfile.TemporaryDirectory(dir=os.path.dirname(directory))
-            tempdir = tempfile.mkdtemp(dir=os.path.dirname(directory))
+            tempdir = tempfile.TemporaryDirectory(dir=os.path.dirname(directory))
         except OSError as e:
             msg = "Failed to create cache directory " + path
             raise SCons.Errors.SConsEnvironmentError(msg) from e
 
-        # TODO: Python 3.7: the context manager raises exception on cleanup
-        #    if the temporary was moved successfully (File Not Found).
-        #    Fixed in 3.8+. In the replacement below we manually clean up if
-        #    the move failed as mkdtemp() does not. TemporaryDirectory's
-        #    cleanup is more sophisitcated so prefer when we can use it.
-        # self._add_config(tempdir.name)
-        # with tempdir:
-        #     try:
-        #         os.replace(tempdir.name, directory)
-        #         return True
-        #     except OSError as e:
-        #         # did someone else get there first?
-        #         if os.path.isdir(directory):
-        #             return False  # context manager cleans up
-        #         msg = "Failed to create cache directory " + path
-        #         raise SCons.Errors.SConsEnvironmentError(msg) from e
-
-        self._add_config(tempdir)
-        try:
-            os.replace(tempdir, directory)
-            return True
-        except OSError as e:
-            # did someone else get there first? attempt cleanup.
-            if os.path.isdir(directory):
-                try:
-                    shutil.rmtree(tempdir)
-                except Exception:  # we tried, don't worry about it
-                    pass
-                return False
-            msg = "Failed to create cache directory " + path
-            raise SCons.Errors.SConsEnvironmentError(msg) from e
+        self._add_config(tempdir.name)
+        with tempdir:
+            try:
+                os.replace(tempdir.name, directory)
+                return True
+            except OSError as e:
+                # did someone else get there first?
+                if os.path.isdir(directory):
+                    return False  # context manager cleans up
+                msg = "Failed to create cache directory " + path
+                raise SCons.Errors.SConsEnvironmentError(msg) from e
 
     def _readconfig(self, path: str) -> None:
         """Read the cache config from *path*.

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -41,6 +41,7 @@ from collections.abc import Callable, Collection
 from subprocess import DEVNULL, PIPE
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, NoReturn, cast, overload
+from typing import Literal as _Literal
 
 import SCons.Action
 import SCons.Builder
@@ -1919,7 +1920,12 @@ class Base(SubstitutionEnvironment):
             if path: return prog
         return None
 
-    # TODO: Overloads based on `as_dict` once py3.8 is the minimum version.
+    @overload
+    def Dictionary(self, *args: str, as_dict: _Literal[False]) -> Any | list[Any]: ...
+
+    @overload
+    def Dictionary(self, *args: str, as_dict: _Literal[True]) -> dict[str, Any]: ...
+
     def Dictionary(self, *args: str, as_dict: bool = False) -> Any | list[Any] | dict[str, Any]:
         """Return construction variables from an environment.
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -67,7 +67,7 @@ from SCons.Util.stats import count_stats, memory_stats, time_stats, ENABLE_JSON,
 from SCons import __version__ as SConsVersion
 
 # these define the range of versions SCons supports
-minimum_python_version = (3, 7, 0)
+minimum_python_version = (3, 9, 0)
 deprecated_python_version = (3, 9, 0)
 
 # ordered list of SConstruct names to look for if there is no -f flag

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -31,7 +31,7 @@ selection method.
 
 import os
 import stat
-from shutil import copy2, copystat
+from shutil import copy2, copytree
 
 import SCons.Action
 import SCons.Tool
@@ -49,109 +49,6 @@ _UNIQUE_INSTALLED_FILES = None
 
 class CopytreeError(OSError):
     pass
-
-
-def scons_copytree(src, dst, symlinks: bool=False, ignore=None, copy_function=copy2,
-                   ignore_dangling_symlinks: bool=False, dirs_exist_ok: bool=False):
-    """Recursively copy a directory tree, SCons version.
-
-    This is a modified copy of the Python 3.7 shutil.copytree function.
-    SCons update: dirs_exist_ok dictates whether to raise an
-    exception in case dst or any missing parent directory already
-    exists. Implementation depends on os.makedirs having a similar
-    flag, which it has since Python 3.2.  This version also raises an
-    SCons-defined exception rather than the one defined locally to shtuil.
-    This version uses a change from Python 3.8.
-    TODO: we can remove this forked copy once the minimum Py version is 3.8.
-
-    If exception(s) occur, an Error is raised with a list of reasons.
-
-    If the optional symlinks flag is true, symbolic links in the
-    source tree result in symbolic links in the destination tree; if
-    it is false, the contents of the files pointed to by symbolic
-    links are copied. If the file pointed by the symlink doesn't
-    exist, an exception will be added in the list of errors raised in
-    an Error exception at the end of the copy process.
-
-    You can set the optional ignore_dangling_symlinks flag to true if you
-    want to silence this exception. Notice that this has no effect on
-    platforms that don't support os.symlink.
-
-    The optional ignore argument is a callable. If given, it
-    is called with the `src` parameter, which is the directory
-    being visited by copytree(), and `names` which is the list of
-    `src` contents, as returned by os.listdir():
-
-        callable(src, names) -> ignored_names
-
-    Since copytree() is called recursively, the callable will be
-    called once for each directory that is copied. It returns a
-    list of names relative to the `src` directory that should
-    not be copied.
-
-    The optional copy_function argument is a callable that will be used
-    to copy each file. It will be called with the source path and the
-    destination path as arguments. By default, copy2() is used, but any
-    function that supports the same signature (like copy()) can be used.
-
-    """
-    names = os.listdir(src)
-    if ignore is not None:
-        ignored_names = ignore(src, names)
-    else:
-        ignored_names = set()
-
-    os.makedirs(dst, exist_ok=dirs_exist_ok)
-    errors = []
-    for name in names:
-        if name in ignored_names:
-            continue
-        srcname = os.path.join(src, name)
-        dstname = os.path.join(dst, name)
-        try:
-            if os.path.islink(srcname):
-                linkto = os.readlink(srcname)
-                if symlinks:
-                    # We can't just leave it to `copy_function` because legacy
-                    # code with a custom `copy_function` may rely on copytree
-                    # doing the right thing.
-                    os.symlink(linkto, dstname)
-                    copystat(srcname, dstname, follow_symlinks=not symlinks)
-                else:
-                    # ignore dangling symlink if the flag is on
-                    if not os.path.exists(linkto) and ignore_dangling_symlinks:
-                        continue
-                    # otherwise let the copy occurs. copy2 will raise an error
-                    if os.path.isdir(srcname):
-                        scons_copytree(srcname, dstname, symlinks=symlinks,
-                                       ignore=ignore, copy_function=copy_function,
-                                       ignore_dangling_symlinks=ignore_dangling_symlinks,
-                                       dirs_exist_ok=dirs_exist_ok)
-                    else:
-                        copy_function(srcname, dstname)
-            elif os.path.isdir(srcname):
-                scons_copytree(srcname, dstname, symlinks=symlinks,
-                               ignore=ignore, copy_function=copy_function,
-                               ignore_dangling_symlinks=ignore_dangling_symlinks,
-                               dirs_exist_ok=dirs_exist_ok)
-            else:
-                # Will raise a SpecialFileError for unsupported file types
-                copy_function(srcname, dstname)
-        # catch the Error from the recursive copytree so that we can
-        # continue with other files
-        except CopytreeError as err:  # SCons change
-            errors.extend(err.args[0])
-        except OSError as why:
-            errors.append((srcname, dstname, str(why)))
-    try:
-        copystat(src, dst)
-    except OSError as why:
-        # Copying file access times may fail on Windows
-        if getattr(why, 'winerror', None) is None:
-            errors.append((src, dst, str(why)))
-    if errors:
-        raise CopytreeError(errors)  # SCons change
-    return dst
 
 #
 # Functions doing the actual work of the Install Builder.
@@ -173,7 +70,7 @@ def copyFunc(dest, source, env) -> int:
             parent = os.path.split(dest)[0]
             if not os.path.exists(parent):
                 os.makedirs(parent)
-        scons_copytree(source, dest, dirs_exist_ok=True)
+        copytree(source, dest, dirs_exist_ok=True)
     else:
         copy2(source, dest)
         st = os.stat(source)

--- a/SCons/Util/__init__.py
+++ b/SCons/Util/__init__.py
@@ -1216,8 +1216,7 @@ class UniqueList(UserList):
         self.__make_unique()
         super().reverse()
 
-    # TODO: Py3.8: def sort(self, /, *args, **kwds):
-    def sort(self, *args, **kwds):
+    def sort(self, /, *args, **kwds):
         self.__make_unique()
         return super().sort(*args, **kwds)
 

--- a/SCons/Util/hashes.py
+++ b/SCons/Util/hashes.py
@@ -330,14 +330,8 @@ def hash_file_signature(fname: str, chunksize: int=65536, hash_format=None) -> s
     """
     m = _get_hash_object(hash_format)
     with open(fname, "rb") as f:
-        while True:
-            blck = f.read(chunksize)
-            if not blck:
-                break
-            m.update(to_bytes(blck))
-        # TODO: can use this when base is Python 3.8+
-        # while (blk := f.read(chunksize)) != b'':
-        #     m.update(to_bytes(blk))
+        while (blk := f.read(chunksize)):
+            m.update(to_bytes(blk))
 
     return m.hexdigest()
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -87,7 +87,7 @@ and a database of information about previous builds so
 details do not have to be recalculated each run.
 </para>
 
-<para>&scons; requires &Python; 3.7 or later to run;
+<para>&scons; requires &Python; 3.9 or later to run;
 there should be no other dependencies or requirements,
 unless the experimental Ninja tool is used (requires the ninja package).
 </para>

--- a/doc/user/build-install.xml
+++ b/doc/user/build-install.xml
@@ -173,7 +173,7 @@ Python 3.9.15
     </para>
 
     <para>
-    &SCons; will work with &Python; 3.7 or later.
+    &SCons; will work with &Python; 3.9 or later.
     If you need to install &Python; and have a choice,
     we recommend using the most recent &Python; version available.
     Newer &Python; versions have significant improvements

--- a/doc/user/misc.xml
+++ b/doc/user/misc.xml
@@ -75,14 +75,14 @@ This file is processed by the bin/SConsDoc.py module.
 
     <scons_example name="misc_EnsurePythonVersion">
       <file name="SConstruct" printme="1">
-EnsurePythonVersion(3, 8)
+EnsurePythonVersion(3, 9)
       </file>
     </scons_example>
 
     -->
 
     <sconstruct>
-EnsurePythonVersion(3, 8)
+EnsurePythonVersion(3, 9)
     </sconstruct>
 
     <para>
@@ -107,7 +107,7 @@ EnsurePythonVersion(3, 8)
 
     <screen>
 % <userinput>scons -Q</userinput>
-Python 3.7 or greater required, but you have Python 3.6.5
+Python 3.9 or greater required, but you have Python 3.6.5
     </screen>
 
   </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools"]
 [project]
 name = "SCons"
 description = "Open Source next-generation build tool."
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = "MIT"  # PEP 639 form (new - setuptools >= 77.0)
 # Should include docbook license, but this fails:
 # license = "MIT AND DocBook-stylesheet"
@@ -22,8 +22,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -97,7 +95,7 @@ dist-dir = "build/dist"
 dist-dir = "build/dist"
 
 [tool.ruff]
-target-version = "py37" # Lowest python version supported
+target-version = "py38" # Lowest python version supported
 extend-include = ["SConstruct", "SConscript"]
 extend-exclude = [
     "bench/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools"]
 [project]
 name = "SCons"
 description = "Open Source next-generation build tool."
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = "MIT"  # PEP 639 form (new - setuptools >= 77.0)
 # Should include docbook license, but this fails:
 # license = "MIT AND DocBook-stylesheet"
@@ -22,8 +22,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -97,7 +95,7 @@ dist-dir = "build/dist"
 dist-dir = "build/dist"
 
 [tool.ruff]
-target-version = "py37" # Lowest python version supported
+target-version = "py39" # Lowest python version supported
 extend-include = ["SConstruct", "SConscript"]
 extend-exclude = [
     "bench/",

--- a/runtest.py
+++ b/runtest.py
@@ -271,7 +271,7 @@ Environment Variables:
     parser.add_argument('-d', '--debug', action='store_true',
                         help="Run test scripts under the Python debugger.")
     parser.add_argument('-D', '--devmode', action='store_true',
-                        help="Run tests in Python's development mode (Py3.7+ only).")
+                        help="Run tests in Python's development mode.")
     parser.add_argument('-e', '--external', action='store_true',
                         help="Run the script in external mode (for external Tools)")
     parser.add_argument('-j', '--jobs', metavar='JOBS', default=1, type=posint,

--- a/scripts/scons-configure-cache.py
+++ b/scripts/scons-configure-cache.py
@@ -48,10 +48,10 @@ __developer__ = "__DEVELOPER__"
 import os
 import sys
 
-# python compatibility check
-if sys.version_info < (3, 7, 0):
+# Python compatibility check
+if sys.version_info < (3, 9, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.7.0 is required.\n"
+Python >= 3.9.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/scons.py
+++ b/scripts/scons.py
@@ -42,9 +42,9 @@ import os
 import sys
 
 # Python compatibility check
-if sys.version_info < (3, 7, 0):
+if sys.version_info < (3, 9, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.7.0 is required.\n"
+Python >= 3.9.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/sconsign.py
+++ b/scripts/sconsign.py
@@ -40,10 +40,10 @@ __developer__ = "__DEVELOPER__"
 import os
 import sys
 
-# python compatibility check
-if sys.version_info < (3, 7, 0):
+# Python compatibility check
+if sys.version_info < (3, 9, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.7.0 is required.\n"
+Python >= 3.9.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 
@@ -84,6 +84,7 @@ sys.path = libs + sys.path
 # END STANDARD SCons SCRIPT HEADER
 ##############################################################################
 from SCons.Utilities.sconsign import main
+
 if __name__ == "__main__":
     main()
     sys.exit(0)

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -75,11 +75,7 @@ env.Package( NAME           = 'foo',
         )
 """ % locals())
 
-
-if sys.version_info.minor >= 8:
-    line_number = 12
-else:
-    line_number = 23
+line_number = 12
 
 expect = """
 scons: *** Setting target is not supported for rpm.

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -57,7 +57,7 @@ from TestCommon import __all__, _python_
 default_version = '4.10.2ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
-python_version_unsupported = (3, 7, 0)
+python_version_unsupported = (3, 9, 0)
 python_version_deprecated = (3, 9, 0)
 python_version_supported_str = "3.9.0"  # str of lowest non-deprecated Python
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -62,7 +62,7 @@ from TestCommon import __all__
 default_version = '4.10.2ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
-python_version_unsupported = (3, 7, 0)
+python_version_unsupported = (3, 9, 0)
 python_version_deprecated = (3, 9, 0)
 python_version_supported_str = "3.9.0"  # str of lowest non-deprecated Python
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -62,7 +62,7 @@ from TestCommon import __all__
 default_version = '4.12.0ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
-python_version_unsupported = (3, 7, 0)
+python_version_unsupported = (3, 9, 0)
 python_version_deprecated = (3, 9, 0)
 python_version_supported_str = "3.9.0"  # str of lowest non-deprecated Python
 


### PR DESCRIPTION
Originally part of #4825 and building off of #4826, this PR aims to integrate the changes made possible by dropping Python 3.7 & 3.8 support. Marking as a draft until 3.7 & 3.8 are properly designated as "deprecated".

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
