### PR TITLE
Docs: add details for VariantDir

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,6 +72,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the general unavailablility of the obsolete build-time Qt3 package.
     - A few more typing cleanups in Environment (and in one case which
       affected it in the Node package).
+    - Clarify VariantDir behavior when switching to not duplicate sources
+      and tweak wording a bit.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -107,6 +107,9 @@ DOCUMENTATION
   Studio 2022 with Windows SDK version 10.0.26100.0 or later installed
   to the known issues in SCons/Tool/MSCommon/README.rst.
 
+- Clarify VariantDir behavior when switching to not duplicate sources
+  and tweak wording a bit.
+
 DEVELOPMENT
 -----------
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -3713,12 +3713,12 @@ env.UpdateValue(target=Value(output), source=Value(input))
 </arguments>
 <summary>
 <para>
-Sets up a mapping to define a variant build directory in
+Set up a mapping to define a variant build directory in
 <parameter>variant_dir</parameter>.
 <parameter>src_dir</parameter> must not be underneath
 <parameter>variant_dir</parameter>.
-A &f-VariantDir; mapping is global, even if called using the
-&f-env-VariantDir; form.
+A &f-VariantDir; mapping is global, even when called as
+&f-env-VariantDir;.
 &f-VariantDir;
 can be called multiple times with the same
 <parameter>src_dir</parameter>
@@ -3726,100 +3726,105 @@ to set up multiple variant builds with different options.
 </para>
 
 <para>
-Note if <parameter>variant_dir</parameter>
-is not under the project top directory,
-target selection rules will not pick targets in the
+Note that while <parameter>variant_dir</parameter>
+can be any convenient location,
+if it is not under the project top directory,
+normal target selection rules will not pick targets in the
 variant directory unless they are explicitly specified.
 </para>
 
 <para>
-When files in <parameter>variant_dir</parameter> are referenced,
-&SCons; backfills as needed with files from <parameter>src_dir</parameter>
-to create a complete build directory.
+When files under <parameter>variant_dir</parameter> are referenced,
+&SCons; backfills missing files from <parameter>src_dir</parameter>
+as needed to create a complete build tree.
 By default, &SCons;
-physically duplicates the source files, SConscript files,
-and directory structure as needed into the variant directory.
-Thus, a build performed in the variant directory is guaranteed to be identical
-to a build performed in the source directory even if
-intermediate source files are generated during the build,
-or if preprocessors or other scanners search for included files
-using paths relative to the source file,
-or if individual compilers or other invoked tools are hard-coded
-to put derived files in the same directory as source files.
-Only the files &SCons; calculates are needed for the build are
+physically duplicates source files, subsidiary &SConscript; files,
+and any needed directory structure into the variant directory.
+This makes a build in the variant directory equivalent to a build in the
+source tree, even when intermediate source files are generated,
+scanners search for included files using source-relative paths,
+or tools are hard-coded to emit derived files beside their sources.
+Only the files &SCons; determines are needed for the build are
 duplicated into <parameter>variant_dir</parameter>.
-If possible on the platform,
-the duplication is performed by linking rather than copying.
-This behavior is affected by the
-<option>--duplicate</option>
-command-line option.
+Where possible, duplication is performed by linking rather than copying.
+The duplication strategy can be adjusted using the
+<link linkend="opt-duplicate"><option>--duplicate</option></link>
+command-line option or &f-link-SetOption;.
 </para>
 
 <para>
-Duplicating the source files may be disabled by setting the
-<parameter>duplicate</parameter>
-argument to
-<constant>False</constant>.
-This will cause
-&SCons;
-to invoke Builders using the path names of source files in
-<parameter>src_dir</parameter>
-and the path names of derived files within
-<parameter>variant_dir</parameter>.
-This is more efficient than duplicating,
-and is safe for most builds;
-revert to <literal>duplicate=True</literal>
-if it causes problems.
+If the <parameter>duplicate</parameter> argument is set to
+<constant>False</constant>,
+&SCons; does not duplicate source files.
+Instead, it automatically invokes builders using the original source paths
+from <parameter>src_dir</parameter>
+and derived file paths in <parameter>variant_dir</parameter>.
+This is more efficient than duplicating and is safe for most builds;
+if it causes problems, use <literal>duplicate=True</literal> (the default).
 </para>
+
+<note>
+<para>
+When switching an existing variant directory
+from duplicating to non-duplicating,
+previously duplicated source files are not automatically removed.
+&SCons; will continue to prefer these stale copies over the original sources,
+possibly preventing detection of changes to the originals.
+To avoid this issue, clean the build tree before switching.
+After the switch,
+&SCons; no longer tracks duplicated files in the variant directory
+and will not remove them during cleaning.
+</para>
+</note>
+
+<para>
+Variant directories can also be established using the
+&f-link-SConscript; function
+in conjunction with calling a subsidiary &SConscript; file.
+</para>
+
+<para>
+Examples:
+</para>
+
+<example_commands>
+# use names in the build directory, not the source directory
+VariantDir('build', 'src', duplicate=False)
+Program('build/prog', 'build/source.c')
+
+# this builds both the source and docs in a separate subtree
+VariantDir('build', '.', duplicate=False)
+SConscript(dirs=['build/src', 'build/doc'])
+
+# same as previous example, but only uses SConscript
+SConscript(dirs='src', variant_dir='build/src', duplicate=False)
+SConscript(dirs='doc', variant_dir='build/doc', duplicate=False)
+</example_commands>
 
 <para>
 &f-VariantDir;
-works most naturally when used with a subsidiary SConscript file.
-The subsidiary SConscript file must be called as if it were in
+works most naturally when used with a subsidiary &SConscript; file.
+The subsidiary &SConscript; must be called as if it were in
 <parameter>variant_dir</parameter>,
 regardless of the value of
 <parameter>duplicate</parameter>.
-When calling an SConscript file, you can use the
-<parameter>exports</parameter> keyword argument
-to pass parameters (individually or as an appropriately set up environment)
-so the SConscript can pick up the right settings for that variant build.
-The SConscript must &f-link-Import; these to use them. Example:
+Use the <parameter>exports</parameter> keyword argument to pass
+parameters or an appropriately configured environment object
+so the subsidiary &SConscript; can pick up the right settings
+for that variant build.
+The &SConscript; must &f-link-Import;
+these exported values before using them.
 </para>
 
 <example_commands>
 env1 = Environment(...settings for variant1...)
 env2 = Environment(...settings for variant2...)
 
-# run src/SConscript in two variant directories
+# run src/SConscript by using the variant dir paths
 VariantDir('build/variant1', 'src')
 SConscript('build/variant1/SConscript', exports={"env": env1})
 VariantDir('build/variant2', 'src')
 SConscript('build/variant2/SConscript', exports={"env": env2})
-</example_commands>
-
-<para>
-See also the
-&f-link-SConscript; function
-for another way to specify a variant directory
-in conjunction with calling a subsidiary SConscript file.
-</para>
-
-<para>
-More examples:
-</para>
-
-<example_commands>
-# use names in the build directory, not the source directory
-VariantDir('build', 'src', duplicate=0)
-Program('build/prog', 'build/source.c')
-
-# this builds both the source and docs in a separate subtree
-VariantDir('build', '.', duplicate=0)
-SConscript(dirs=['build/src','build/doc'])
-
-# same as previous example, but only uses SConscript
-SConscript(dirs='src', variant_dir='build/src', duplicate=0)
-SConscript(dirs='doc', variant_dir='build/doc', duplicate=0)
 </example_commands>
 </summary>
 </scons_function>


### PR DESCRIPTION
Point out a pitfall when switching from duplicating sources to not duplicating sources.  Rearrange order of examples and clarify some descriptions.

Doc-only change.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
