### PR TITLE
Add support for Python 3.15

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       on a one-time uuid to make a path to the file.
     - Clarify VariantDir behavior when switching to not duplicate sources
       and tweak wording a bit.
+    - Test suite: add support for Python 3.15 in the Action unit tests.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -71,7 +71,7 @@ IMPROVEMENTS
 - Simplified and sped up compilation database generation. No longer requires
   each entry to have a dedicated node that's always built; instead, the database
   *itself* is set to always build.
-  
+
 - Switch remaining "original style" docstring parameter listings to Google style.
 
 - Additional small tweaks to Environment.py type hints, fold some overly
@@ -80,6 +80,8 @@ long function signature lines, and some linting-insipired cleanups.
 - Test framework: tweak module docstrings
 
 - Test suite: end to end tests don't use assert in result checks
+
+- Test suite: add support for Python 3.15 in the Action unit tests.
 
 
 PACKAGING

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -43,9 +43,9 @@ import os
 import sys
 import types
 import unittest
-from unittest import mock
 from subprocess import PIPE
 from typing import TYPE_CHECKING
+from unittest import mock
 
 # If assertEqual truncates strings so it's hard to see the diff, enable this:
 # if 'unittest.util' in __import__('sys').modules:
@@ -1557,6 +1557,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
             (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
+            (3, 15): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00\x00\x00Q\x00!\x00),(),()'),
         }
 
         meth_matches = [
@@ -1738,6 +1739,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
             (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
+            (3, 15): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00\x00\x00Q\x00!\x00),(),()'),
 
         }
 
@@ -1750,6 +1752,8 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 12): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'1, 1, 0, 0,(),(),(\x95\x00g\x00),(),()'),
             (3, 14): bytearray(b'1, 1, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
+            (3, 15): bytearray(b'1, 1, 0, 0,(),(),(\x80\x00\x00\x00Q\x00!\x00),(),()'),
+
         }
 
         def factory(act, **kw):
@@ -1991,6 +1995,7 @@ class LazyActionTestCase(unittest.TestCase):
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
             (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
+            (3, 15): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00\x00\x00Q\x00!\x00),(),()'),
         }
 
         meth_matches = [
@@ -2054,6 +2059,7 @@ class ActionCallerTestCase(unittest.TestCase):
             (3, 12): b'\x97\x00y\x00',
             (3, 13): b'\x95\x00g\x00',
             (3, 14): b'\x80\x00R\x00#\x00',
+            (3, 15): b'\x80\x00\x00\x00Q\x00!\x00',
         }
 
         with self.subTest():
@@ -2260,6 +2266,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 12): (bytearray(b"3, 3, 0, 0,(),(),(\x97\x00|\x00S\x00),(),()"),),
             (3, 13): (bytearray(b"3, 3, 0, 0,(),(),(\x95\x00U\x00$\x00),(),()"),),
             (3, 14): (bytearray(b"3, 3, 0, 0,(),(),(\x80\x00V\x00#\x00),(),()"),),
+            (3, 15): bytearray(b'3, 3, 0, 0,(),(),(\x80\x00\x00\x00U\x00!\x00),(),()'),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2301,6 +2308,9 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 14): bytearray(
                 b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00R\x00V\x00n\x00\x00\x00\x00\x00\x00\x00\x00\x00R\x01V\x00n\x01\x00\x00\x00\x00\x00\x00\x00\x00R\x02#\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()}}{{{a=a,b=b}}}"
             ),
+            (3, 15): bytearray(
+                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00\x00\x00Q\x00U\x00m\x00\x00\x00\x00\x00\x00\x00\x00\x00Q\x01U\x00m\x01\x00\x00\x00\x00\x00\x00\x00\x00Q\x02!\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00\x00\x00Q\x00!\x00),(),()}}{{{a=a,b=b}}}"
+            ),
         }
         self.assertEqual(c, expected[sys.version_info[:2]])
 
@@ -2335,6 +2345,9 @@ class ObjectContentsTestCase(unittest.TestCase):
             ),
             (3, 14): bytearray(
                 b"0, 0, 0, 0,(Hello, World!),(print),(\x80\x00]\x00!\x00R\x004\x01\x00\x00\x00\x00\x00\x00\x1f\x00R\x01#\x00)"
+            ),
+            (3, 15): bytearray(
+                b"0, 0, 0, 0,(Hello, World!),(print),(\x80\x00\x00\x00\\\x00\x1f\x00Q\x002\x01\x00\x00\x00\x00\x00\x00\x1d\x00Q\x01!\x00)"
             ),
         }
 


### PR DESCRIPTION
This change affects only the ActionTests.py test, which has version-indexed bytecode strings. This is tested working as of 3.15.0a8, which was the first time the bytecode changed - and billed as the last planned alpha (now looks like there might be one more)

Note the CI won't touch the 3.15 code path... it would need a test that included something like
```yaml
steps:
- uses: actions/checkout@v6
- uses: actions/setup-python@v6
  with:
    python-version: '3.15-dev'
```

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
