### PR TITLE
Modernize zipfile usage in zip tool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       on a one-time uuid to make a path to the file.
     - Clarify VariantDir behavior when switching to not duplicate sources
       and tweak wording a bit.
+    - zip tool now uses zipfile module's "from_file" method to populate
+      ZipInfo records, rather than doing manually.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -71,7 +71,7 @@ IMPROVEMENTS
 - Simplified and sped up compilation database generation. No longer requires
   each entry to have a dedicated node that's always built; instead, the database
   *itself* is set to always build.
-  
+
 - Switch remaining "original style" docstring parameter listings to Google style.
 
 - Additional small tweaks to Environment.py type hints, fold some overly
@@ -80,6 +80,9 @@ long function signature lines, and some linting-insipired cleanups.
 - Test framework: tweak module docstrings
 
 - Test suite: end to end tests don't use assert in result checks
+
+- zip tool now uses zipfile module's "from_file" method to populate ZipInfo
+  records, rather than doing manually.
 
 
 PACKAGING

--- a/SCons/Tool/zip.py
+++ b/SCons/Tool/zip.py
@@ -29,41 +29,36 @@ Tool-specific initialization for zip.
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()
 selection method.
-
 """
 
 import os
 
+import SCons.Action
 import SCons.Builder
 import SCons.Defaults
 import SCons.Node.FS
 import SCons.Util
 
-import time
 import zipfile
 
 
 zip_compression = zipfile.ZIP_DEFLATED
 
 
-def _create_zipinfo_for_file(fname, arcname, date_time, compression):
-    st = os.stat(fname)
-    if not date_time:
-        mtime = time.localtime(st.st_mtime)
-        date_time = mtime[0:6]
-    zinfo = zipfile.ZipInfo(filename=arcname, date_time=date_time)
-    zinfo.external_attr = (st.st_mode & 0xFFFF) << 16  # Unix attributes
+def _create_zipinfo_for_file(fname: str, arcname: str, date_time: tuple, compression: int) -> zipfile.ZipInfo:
+    zinfo = zipfile.ZipInfo.from_file(fname, arcname)
+    if date_time:
+        zinfo.date_time = date_time
     zinfo.compress_type = compression
-    zinfo.file_size = st.st_size
     return zinfo
 
 
 def zip_builder(target, source, env) -> None:
-    compression = env.get('ZIPCOMPRESSION', zipfile.ZIP_STORED)
-    zip_root = str(env.get('ZIPROOT', ''))
-    date_time = env.get('ZIP_OVERRIDE_TIMESTAMP')
+    compression: int = env.get('ZIPCOMPRESSION', zipfile.ZIP_STORED)
+    zip_root: str = str(env.get('ZIPROOT', ''))
+    date_time: tuple = env.get('ZIP_OVERRIDE_TIMESTAMP')
 
-    files = []
+    files: list[str] = []
     for s in source:
         if s.isdir():
             for dirpath, dirnames, filenames in os.walk(str(s)):
@@ -74,10 +69,9 @@ def zip_builder(target, source, env) -> None:
         else:
             files.append(str(s))
 
-    with zipfile.ZipFile(str(target[0]), 'w', compression) as zf:
+    with zipfile.ZipFile(str(target[0]), mode='w', compression=compression) as zf:
         for fname in files:
             arcname = os.path.relpath(fname, zip_root)
-            # TODO: Switch to ZipInfo.from_file when 3.6 becomes the base python version
             zinfo = _create_zipinfo_for_file(fname, arcname, date_time, compression)
             with open(fname, "rb") as f:
                 zf.writestr(zinfo, f.read())
@@ -92,7 +86,7 @@ ZipBuilder = SCons.Builder.Builder(action=SCons.Action.Action('$ZIPCOM', '$ZIPCO
                                    source_factory=SCons.Node.FS.Entry,
                                    source_scanner=SCons.Defaults.DirScanner,
                                    suffix='$ZIPSUFFIX',
-                                   multi=1)
+                                   multi=True)
 
 
 def generate(env) -> None:


### PR DESCRIPTION
`SCons/Tool/zip.py` had a TODO suggesting there was more native way to create `ZipInfo` objects once Python 3.6 became the SCons minimum. This was not implemented yet so this change provides that update. Also adds a bit of type annotation.

No test changes: the existing tests verify the behavior did not change; this is not visible to users.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
