### PR TITLE
Fix compile_commands.json having incorrect include paths for clean builds when a variant dir is used, duplicate=0, and a relative CPPPATH is used in a child SConscript

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -95,6 +95,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       since release 4.0, when the content was used to populate the new
       SCons Cookbook.
 
+  From Will Toohey:
+    - Fix compile_commands.json having incorrect include paths for clean builds
+      when a variant dir is used, duplicate=0, and a relative CPPPATH is used in
+      a child SConscript.
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -51,6 +51,9 @@ FIXES
   directory for each writer before doing the move, instead of depending
   on a one-time uuid to make a path to the file.
 
+- Fix compile_commands.json having incorrect include paths for clean builds when a
+  variant dir is used, duplicate=0, and a relative CPPPATH is used in a child SConscript.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -3305,7 +3305,6 @@ class File(Base):
             self._specific_sources = False
             self._labspath = ""
             self._save_str()
-            self.cwd = None
 
             self.scanner_paths = None
 

--- a/test/CompilationDatabase/fixture/SConstruct_variant
+++ b/test/CompilationDatabase/fixture/SConstruct_variant
@@ -49,3 +49,5 @@ env.Program('build2/main', 'build2/test_main.c')
 env.VariantDir('build3','src', duplicate=0)
 env.InstallAs('build3/test_main_copy.c', 'src/test_main.c')
 env.Program('build3/main', 'build3/test_main_copy.c')
+
+SConscript('src/SConscript_cpppath', variant_dir='build4', duplicate=0, exports={'env': env})

--- a/test/CompilationDatabase/fixture/src_SConscript_cpppath
+++ b/test/CompilationDatabase/fixture/src_SConscript_cpppath
@@ -1,0 +1,2 @@
+Import('env')
+env.Object('test_main.c', CPPPATH=['inc'])

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -40,6 +40,7 @@ test.file_fixture('mygcc.py')
 
 test.verbose_set(1)
 test.file_fixture('fixture/SConstruct_variant', 'SConstruct')
+test.file_fixture('fixture/src_SConscript_cpppath', 'src/SConscript_cpppath')
 test.file_fixture('test_main.c', 'src/test_main.c')
 test.run()
 
@@ -84,6 +85,12 @@ example_rel_file = """[
         "directory": "%(workdir)s",
         "file": "%(variant3_src_file)s",
         "output": "%(output3_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output4_file)s -c -I%(inc_build4)s -I%(inc_src)s %(src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(src_file)s",
+        "output": "%(output4_file)s"
     }
 ]
 """ % {'exe': sys.executable,
@@ -92,8 +99,11 @@ example_rel_file = """[
         'output_file': os.path.join('build', 'test_main.o'),
         'output2_file': os.path.join('build2', 'test_main.o'),
         'output3_file': os.path.join('build3', 'test_main_copy.o'),
+        'output4_file': os.path.join('build4', 'test_main.o'),
         'variant_src_file': os.path.join('build', 'test_main.c'),
-        'variant3_src_file': os.path.join('build3', 'test_main_copy.c')
+        'variant3_src_file': os.path.join('build3', 'test_main_copy.c'),
+        'inc_build4': os.path.join('build4', 'inc'),
+        'inc_src': os.path.join('src', 'inc'),
         }
 
 if sys.platform == 'win32':
@@ -122,6 +132,12 @@ example_abs_file = """[
         "directory": "%(workdir)s",
         "file": "%(abs_variant3_src_file)s",
         "output": "%(abs_output3_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output4_file)s -c -I%(inc_build4)s -I%(inc_src)s %(src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(abs_src_file)s",
+        "output": "%(abs_output4_file)s"
     }
 ]
 """ % {'exe': sys.executable,
@@ -131,12 +147,16 @@ example_abs_file = """[
         'abs_output_file': os.path.join(test.workdir, 'build', 'test_main.o'),
         'abs_output2_file': os.path.join(test.workdir, 'build2', 'test_main.o'),
         'abs_output3_file': os.path.join(test.workdir, 'build3', 'test_main_copy.o'),
+        'abs_output4_file': os.path.join(test.workdir, 'build4', 'test_main.o'),
         'output_file': os.path.join('build', 'test_main.o'),
         'output2_file': os.path.join('build2', 'test_main.o'),
         'output3_file': os.path.join('build3', 'test_main_copy.o'),
+        'output4_file': os.path.join('build4', 'test_main.o'),
         'abs_variant3_src_file': os.path.join(test.workdir, 'build3', 'test_main_copy.c'),
         'variant_src_file': os.path.join('build', 'test_main.c'),
-        'variant3_src_file': os.path.join('build3', 'test_main_copy.c')
+        'variant3_src_file': os.path.join('build3', 'test_main_copy.c'),
+        'inc_build4': os.path.join('build4', 'inc'),
+        'inc_src': os.path.join('src', 'inc'),
         }
 
 if sys.platform == 'win32':

--- a/test/fixture/mygcc.py
+++ b/test/fixture/mygcc.py
@@ -33,7 +33,7 @@ def fake_gcc():
         sys.exit(0)
 
     compiler = sys.argv[1].encode('utf-8')
-    opts, args = getopt.getopt(sys.argv[2:], 'co:xf:K:')
+    opts, args = getopt.getopt(sys.argv[2:], 'co:xf:K:I:')
     for opt, arg in opts:
         if opt == '-o':
             out = arg


### PR DESCRIPTION
I have a somewhat complicated build that uses variants, `duplicate=0`, and a relative include path in a child Sconscript.

On a clean build (and _only_ on a clean build), `built()` is called on the target which wipes its `cwd` in the name of reduced memory use; but when the compiledb is generated, it needs this information to emit accurate include paths, so they end up pointing nowhere useful.

The cwd that gets set to None hangs around in memory anyway as part of the entire Dir tree, so by just not clearing it, the compiledb is accurate to the actual executed command.

## AI disclaimer
This was a nasty thing to triage, Claude helped whittle down my big repo to a minimal repro case and wrote the testcase. I stopped it from doing large architectural changes to fix the issue. Changelog/this PR is all human written.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
