### PR TITLE
Make sure PathListCache is in API docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -55,8 +55,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Handle the default (unset) ProgressObject differently for the sole
       purpose of avoiding Sphinx 9.0+ blowing up on it (it's been giving
       a warning for years, but now it's a fatal error).
-    - Improve covarage of API doc build by ignoring any setting of
+    - Improve coverage of "API docs" build by ignoring any setting of
       __all__ in a package and not showing inherited members from optparse.
+      Add a trick to make sure the build sees PathListCache while
+      generating docs (in normal operation, it's removed so was not visible).
     - Fix --debug=includes for case of multiple source files.
     - Unify internal "_null" sentinel usage.
     - All functions/classes/non-dunder methods in Environment have docstrings.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -110,8 +110,10 @@ DOCUMENTATION
   a warning for years, but now it's a fatal error). Affects only the
   API doc build.
 
-- Improve coverage of API doc build by ignoring any setting of
+- Improve coverage of "API doc" build by ignoring any setting of
   __all__ in a package and not showing inherited members from optparse.
+  Add a trick to make sure build sees PathListCache while generating
+  docs (in normal operation, it's removed so was not visible).
 
 - All functions/classes/non-dunder methods in Environment now have docstrings.
 

--- a/SCons/PathList.py
+++ b/SCons/PathList.py
@@ -30,6 +30,7 @@ still keeping the evaluation delayed so that we Do the Right Thing
 """
 
 import os
+import sys
 
 import SCons.Memoize
 import SCons.Node
@@ -216,6 +217,7 @@ class PathListCache:
 
 PathList = PathListCache().PathList
 
-# TODO: removing the class object here means Sphinx doesn't pick up its
-#   docstrings: they're fine for reading here, but are not in API Docs.
-del PathListCache
+# Some trickery here so Sphinx can still see the class when building API docs
+_SPHINX_BUILD = os.environ.get("SPHINX_BUILD") == "1"
+if not _SPHINX_BUILD:
+    del PathListCache

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -23,6 +23,9 @@ sys.path.insert(0, os.path.abspath('../../testing/framework'))
 sys.path.insert(0, os.path.abspath('../../bin'))
 sys.path.insert(0, os.path.abspath('../../'))
 
+# Set a marker in case code needs to know it's running under sphinx-build
+os.environ.setdefault("SPHINX_BUILD", "1")
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
Previously, the class object was removed after a reference to one method in it was saved as a module-global symbol. This is a cheap way to implement the class as a singleton, but it meant it wasn't documented in the API docs since the class was no longer present once the module has run and the object is introspected by Sphinx. Now set a flag when running Sphinx so the class object can be retained in that case only.

As noted in Discord discussion, two other approaches that would have avoided using an environment variable were suggested and tried (`if 'sphinx-build'  in sys.argv[0]:` and `if 'sphinx' in sys.modules:`) seems like they should work, but don't.  In the interest of expediency, and since this is such a minor change, I'm proposing the approach that did work.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
