### PR TITLE
Remove "below" from user guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Prabhu S. Khalsa:
     - Fix typo in preface
+    - Remove word "below" when content is not actually located below
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -138,6 +138,8 @@ DOCUMENTATION
 - Update documentation for IMPLICIT_COMMAND_DEPENDENCIES construction variable.
 
 - Fix typo in preface
+- Remove word "below" when content is not actually located below
+
 
 DEVELOPMENT
 -----------

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -76,7 +76,7 @@ This file is processed by the bin/SConsDoc.py module.
     including defining types, default values, help text,
     and automatic validation,
     as well as applying those to a &consenv;.
-    See <xref linkend="sect-command-line-variables"></xref>, below.
+    See <xref linkend="sect-command-line-variables"></xref>.
 
     </para>
     </listitem>
@@ -97,7 +97,7 @@ This file is processed by the bin/SConsDoc.py module.
     &SCons; provides access to the list of specified targets,
     as well as ways to set the default list of targets
     from within the &SConscript; files.
-    See <xref linkend="sect-command-line-targets"></xref>, below.
+    See <xref linkend="sect-command-line-targets"></xref>.
 
     </para>
     </listitem>

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -380,7 +380,7 @@ environment, of directory names, suffixes, etc.
     is the ability to create multiple &consenvs;,
     including the ability to clone a new, customized
     &consenv; from an existing &consenv;.
-    See <xref linkend="sect-construction-environments"></xref>, below.
+    See <xref linkend="sect-construction-environments"></xref>.
 
     </para>
     </listitem>
@@ -400,7 +400,7 @@ environment, of directory names, suffixes, etc.
     Note that this is not the same as
     the external environment
     (see above).
-    See <xref linkend="sect-execution-environments"></xref>, below.
+    See <xref linkend="sect-execution-environments"></xref>.
 
     </para>
     </listitem>

--- a/doc/user/hierarchy.xml
+++ b/doc/user/hierarchy.xml
@@ -433,7 +433,7 @@ x
 
     (Notice that the <literal>lib/foo1.o</literal> object file
     is built in the same directory as its source file.
-    See <xref linkend="chap-separate"></xref>, below,
+    See <xref linkend="chap-separate"></xref>,
     for information about
     how to build the object file in a different subdirectory.)
 
@@ -532,7 +532,7 @@ x
     (As was the case with top-relative path names,
     notice that the <literal>/usr/joe/lib/foo1.o</literal> object file
     is built in the same directory as its source file.
-    See <xref linkend="chap-separate"></xref>, below,
+    See <xref linkend="chap-separate"></xref>,
     for information about
     how to build the object file in a different subdirectory.)
 

--- a/doc/user/less-simple.xml
+++ b/doc/user/less-simple.xml
@@ -533,7 +533,7 @@ void bar2() { printf("bar2.c\n"); }
     the individual object files must be built
     before the resulting program can be built.
     (This will be covered in greater detail in
-    <xref linkend="chap-depends"/>, below.)
+    <xref linkend="chap-depends"/>.)
 
     </para>
 
@@ -550,7 +550,7 @@ void bar2() { printf("bar2.c\n"); }
     from the common source files,
     which can then be linked into resulting programs.
     (Creating libraries is discussed in
-    <xref linkend="chap-libraries"></xref>, below.)
+    <xref linkend="chap-libraries"></xref>.)
 
     </para>
 

--- a/doc/user/libraries.xml
+++ b/doc/user/libraries.xml
@@ -147,7 +147,7 @@ object file
 
       Of course, in this example, the object files
       must already exist for the build to succeed.
-      See <xref linkend="chap-nodes"></xref>, below,
+      See <xref linkend="chap-nodes"></xref>,
       for information about how you can
       build object files explicitly
       and include the built files in a library.

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -279,7 +279,7 @@ int main() { printf("Hello, world!\n"); }
     then to look in the directories in the preprocessor search path.
     Add to this that the &SCons; implementation of
     support for code repositories
-    (described below)
+    (described later)
     means not all of the files
     will be found in the same directory hierarchy,
     and the simplest way to make sure

--- a/doc/user/simple.xml
+++ b/doc/user/simple.xml
@@ -439,7 +439,7 @@ Program("#goodbye.c") # the # in "#goodbye" does not indicate a comment
      take those steps if/when it's necessary.
      you'll learn more about how
      &SCons; decides when building or rebuilding a target
-     is necessary in <xref linkend="chap-depends"></xref>, below.
+     is necessary in <xref linkend="chap-depends"></xref>.
 
      </para>
 


### PR DESCRIPTION
When using the multiple pages user guide, the word "below" is used incorrectly in multiple places. It is referencing material that comes later, but cannot be found "below."

There are several places where the word "below" is used just after a link. Those instances are not necessarily needed either, but when the material was in fact "below" I left the word there.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
