### PR TITLE
Fix typo in chapter 6 of user guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Prabhu S. Khalsa:
     - Fix typo in preface
+    - Fix typo in Chapter 6 of User Guide
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -138,6 +138,7 @@ DOCUMENTATION
 - Update documentation for IMPLICIT_COMMAND_DEPENDENCIES construction variable.
 
 - Fix typo in preface
+- Fix typo in Chapter 6 of User Guide
 
 DEVELOPMENT
 -----------

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -1084,7 +1084,7 @@ SetOption('implicit_cache', 1)
     Sometimes a file depends on another file
     that is not detected by an &SCons; scanner.
     For this situation,
-    &SCons; allows you to specific explicitly that one file
+    &SCons; allows you to specify explicitly that one file
     depends on another file,
     and must be rebuilt whenever that file changes.
     This is specified using the &f-link-Depends; method:


### PR DESCRIPTION
The word "specific" is meant to say "specify"

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
