### PR TITLE
Fix typo in chapter 9 of user guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Prabhu S. Khalsa:
     - Fix typo in preface
+    - Fix typo in Chapter 9 of User Guide
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -138,6 +138,7 @@ DOCUMENTATION
 - Update documentation for IMPLICIT_COMMAND_DEPENDENCIES construction variable.
 
 - Fix typo in preface
+- Fix typo in Chapter 9 of User Guide
 
 DEVELOPMENT
 -----------

--- a/doc/user/output.xml
+++ b/doc/user/output.xml
@@ -651,7 +651,7 @@ atexit.register(print_build_failures)
     the same file as the <literal>node</literal>; the
     <literal>node</literal> is the target that was
     being built when the error occurred, while the
-    <literal>filename</literal>is the file or dir that
+    <literal>filename</literal> is the file or dir that
     actually caused the error.
     Note:  only call &GetBuildFailures; at the end of the
     build; calling it at any other time is undefined.


### PR DESCRIPTION
Missing space between the words filename and is

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
