### PR TITLE
Fix typo in chapter 10 of User Guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Prabhu S. Khalsa:
     - Fix typo in preface
+    - Fix typo in Chapter 10 of User Guide
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -138,6 +138,7 @@ DOCUMENTATION
 - Update documentation for IMPLICIT_COMMAND_DEPENDENCIES construction variable.
 
 - Fix typo in preface
+- Fix typo in Chapter 10 of User Guide
 
 DEVELOPMENT
 -----------

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -48,7 +48,7 @@ This file is processed by the bin/SConsDoc.py module.
     <para>
 
     Command-line arguments that begin with a
-    <literal>-</literal> (hyphen) characters
+    <literal>-</literal> (hyphen) character
     are called <firstterm>options</firstterm>.
     &SCons; provides ways for you to examine
     and act on options and their values,


### PR DESCRIPTION
The word characters should not be plural

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
