### PR TITLE
Subst cleanups

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -130,6 +130,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       files as advertised.
     - zip tool now uses zipfile module's "from_file" method to populate
       ZipInfo records, rather than doing manually.
+    - Some cleanups in Subst.py. Functionality does not change.
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -74,6 +74,7 @@ IMPROVEMENTS
   * Fix for_signature logic bug in ListSubber.expand() for correct signature
     generation
   * Modernize string formatting to f-strings
+  Also, separately, some code-style cleanups in Subst.py.
 
 - Test runner reworked to use Python logging; the portion of the test suite
   which tests the runner was adjusted to match.
@@ -95,9 +96,12 @@ long function signature lines, and some linting-inspired cleanups.
 
 - Don't duplicate the creation of Tool objects if "default" is part of
   the tool list.
+
 - Test suite: add support for Python 3.15 in the Action unit tests.
+
 - zip tool now uses zipfile module's "from_file" method to populate ZipInfo
   records, rather than doing manually.
+
 
 
 PACKAGING

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -54,8 +54,7 @@ def raise_exception(exception, target, s):
     msg = f"{name} `{exception}' trying to evaluate `{s}'"
     if target:
         raise SCons.Errors.BuildError(target[0], msg)
-    else:
-        raise SCons.Errors.UserError(msg)
+    raise SCons.Errors.UserError(msg)
 
 
 class Literal:
@@ -65,6 +64,7 @@ class Literal:
     be interpreted as literal.  When passed to the command interpreter,
     all special characters will be escaped.
     """
+
     def __init__(self, lstr) -> None:
         self.lstr = lstr
 
@@ -144,6 +144,7 @@ class CmdStringHolder(UserString):
     will be escaped, quoted, or neither depending on the value of
     *literal* and the string contents.
     """
+
     def __init__(self, cmd, literal: bool = False) -> None:
         super().__init__(cmd)
         self.literal = literal
@@ -160,23 +161,24 @@ class CmdStringHolder(UserString):
         After calling this function, the next call to str() will
         return the escaped string.
         """
-        if self.is_literal():
-            return escape_func(self.data)
-        elif ' ' in self.data or '\t' in self.data:
-            return quote_func(self.data)
-        else:
-            return self.data
+        data = self.data
+        if self.literal:
+            return escape_func(data)
+        if ' ' in data or '\t' in data:
+            return quote_func(data)
+        return data
 
 def escape_list(mylist, escape_func) -> list[str]:
     """Escape a list of arguments by running the specified escape_func
     on every object in the list that has an escape() method."""
+
     def escape(obj, escape_func=escape_func):
         try:
             e = obj.escape
         except AttributeError:
             return obj
-        else:
-            return e(escape_func)
+        return e(escape_func)
+
     return list(map(escape, mylist))
 
 class NLWrapper:
@@ -195,8 +197,10 @@ class NLWrapper:
     def __init__(self, list, func) -> None:
         self.list = list
         self.func = func
+
     def _return_nodelist(self):
         return self.nodelist
+
     def _gen_nodelist(self):
         mylist = self.list
         if mylist is None:
@@ -208,6 +212,7 @@ class NLWrapper:
         self.nodelist = SCons.Util.NodeList(list(map(self.func, mylist)))
         self._create_nodelist = self._return_nodelist
         return self.nodelist
+
     _create_nodelist = _gen_nodelist
 
 
@@ -221,17 +226,22 @@ class Targets_or_Sources(UserList):
     class as a list during variable expansion.  We're not really using any
     :class:`~collections.UserList` methods in practice.
     """
+
     def __init__(self, nl) -> None:
         self.nl = nl
+
     def __getattr__(self, attr):
         nl = self.nl._create_nodelist()
         return getattr(nl, attr)
+
     def __getitem__(self, i):
         nl = self.nl._create_nodelist()
         return nl[i]
+
     def __str__(self) -> str:
         nl = self.nl._create_nodelist()
         return str(nl)
+
     def __repr__(self) -> str:
         nl = self.nl._create_nodelist()
         return repr(nl)
@@ -242,8 +252,10 @@ class Target_or_Source:
     to access an individual proxy Node, calling the NLWrapper to create
     a proxy on demand.
     """
+
     def __init__(self, nl) -> None:
         self.nl = nl
+
     def __getattr__(self, attr):
         nl = self.nl._create_nodelist()
         try:
@@ -253,20 +265,27 @@ class Target_or_Source:
             # pass through, so raise AttributeError for everything.
             raise AttributeError(f"NodeList has no attribute: {attr}")
         return getattr(nl0, attr)
+
     def __str__(self) -> str:
         nl = self.nl._create_nodelist()
         if nl:
             return str(nl[0])
         return ''
+
     def __repr__(self) -> str:
         nl = self.nl._create_nodelist()
         if nl:
             return repr(nl[0])
         return ''
 
+
 class NullNodeList(SCons.Util.NullSeq):
-  def __call__(self, *args, **kwargs) -> str: return ''
-  def __str__(self) -> str: return ''
+    def __call__(self, *args, **kwargs) -> str:
+        return ''
+
+    def __str__(self) -> str:
+        return ''
+
 
 NullNodesList = NullNodeList()
 
@@ -284,30 +303,33 @@ def subst_dict(target, source):
              used to generate the SOURCES and SOURCE
              construction variables
     """
-    dict = {}
+    substitutions = {}
 
     if target:
+
         def get_tgt_subst_proxy(thing):
             try:
                 subst_proxy = thing.get_subst_proxy()
             except AttributeError:
-                subst_proxy = thing # probably a string, just return it
+                subst_proxy = thing  # probably a string, just return it
             return subst_proxy
+
         tnl = NLWrapper(target, get_tgt_subst_proxy)
-        dict['TARGETS'] = Targets_or_Sources(tnl)
-        dict['TARGET'] = Target_or_Source(tnl)
+        substitutions['TARGETS'] = Targets_or_Sources(tnl)
+        substitutions['TARGET'] = Target_or_Source(tnl)
 
         # This is a total cheat, but hopefully this dictionary goes
         # away soon anyway.  We just let these expand to $TARGETS
         # because that's "good enough" for the use of ToolSurrogates
         # (see test/ToolSurrogate.py) to generate documentation.
-        dict['CHANGED_TARGETS'] = '$TARGETS'
-        dict['UNCHANGED_TARGETS'] = '$TARGETS'
+        substitutions['CHANGED_TARGETS'] = '$TARGETS'
+        substitutions['UNCHANGED_TARGETS'] = '$TARGETS'
     else:
-        dict['TARGETS'] = NullNodesList
-        dict['TARGET'] = NullNodesList
+        substitutions['TARGETS'] = NullNodesList
+        substitutions['TARGET'] = NullNodesList
 
     if source:
+
         def get_src_subst_proxy(node):
             try:
                 rfile = node.rfile
@@ -318,22 +340,23 @@ def subst_dict(target, source):
             try:
                 return node.get_subst_proxy()
             except AttributeError:
-                return node     # probably a String, just return it
+                return node  # probably a String, just return it
+
         snl = NLWrapper(source, get_src_subst_proxy)
-        dict['SOURCES'] = Targets_or_Sources(snl)
-        dict['SOURCE'] = Target_or_Source(snl)
+        substitutions['SOURCES'] = Targets_or_Sources(snl)
+        substitutions['SOURCE'] = Target_or_Source(snl)
 
         # This is a total cheat, but hopefully this dictionary goes
         # away soon anyway.  We just let these expand to $TARGETS
         # because that's "good enough" for the use of ToolSurrogates
         # (see test/ToolSurrogate.py) to generate documentation.
-        dict['CHANGED_SOURCES'] = '$SOURCES'
-        dict['UNCHANGED_SOURCES'] = '$SOURCES'
+        substitutions['CHANGED_SOURCES'] = '$SOURCES'
+        substitutions['UNCHANGED_SOURCES'] = '$SOURCES'
     else:
-        dict['SOURCES'] = NullNodesList
-        dict['SOURCE'] = NullNodesList
+        substitutions['SOURCES'] = NullNodesList
+        substitutions['SOURCE'] = NullNodesList
 
-    return dict
+    return substitutions
 
 
 _callable_args_set = {'target', 'source', 'env', 'for_signature'}
@@ -380,7 +403,6 @@ class StringSubber:
     the expansion.
     """
 
-
     def __init__(self, env, mode: int, conv, gvars: dict) -> None:
         self.env = env
         self.mode = mode
@@ -407,70 +429,73 @@ class StringSubber:
             if s1 == '$':
                 # In this case keep the double $'s which we'll later
                 # swap for a single dollar sign as we need to retain
-                # this information to properly avoid matching "$("" when
-                # the actual text was "$$(""  (or "$)"" when "$$)"" )
+                # this information to properly avoid matching "$(" when
+                # the actual text was "$$("  (or "$)" from "$$)" )
                 return '$$'
-            elif s1 in '()':
+            if s1 in '()':
                 return s
+            key = s[1:]
+            if key[0] == '{':
+                key = key[1:-1]
+
+            # Store for error messages if we fail to expand the value
+            old_s = s
+            s = None
+            if key in lvars:
+                s = lvars[key]
+            elif key in self.gvars:
+                s = self.gvars[key]
             else:
-                key = s[1:]
-                if key[0] == '{':
-                    key = key[1:-1]
+                try:
+                    s = eval(key, self.gvars, lvars)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:
+                    if e.__class__ in AllowableExceptions:
+                        return ''
+                    raise_exception(e, lvars['TARGETS'], old_s)
 
-                # Store for error messages if we fail to expand the
-                # value
-                old_s = s
-                s = None
-                if key in lvars:
-                     s = lvars[key]
-                elif key in self.gvars:
-                     s = self.gvars[key]
-                else:
-                     try:
-                          s = eval(key, self.gvars, lvars)
-                     except KeyboardInterrupt:
-                          raise
-                     except Exception as e:
-                          if e.__class__ in AllowableExceptions:
-                               return ''
-                          raise_exception(e, lvars['TARGETS'], old_s)
+            if s is None and NameError not in AllowableExceptions:
+                raise_exception(NameError(key), lvars['TARGETS'], old_s)
 
-                if s is None and NameError not in AllowableExceptions:
-                     raise_exception(NameError(key), lvars['TARGETS'], old_s)
-                elif s is None:
-                     return ''
+            if s is None:
+                return ''
 
-                # A plain string with no more expansions needs no
-                # further processing, so skip the copy/recursion below.
-                if isinstance(s, str) and '$' not in s:
-                    return s
+            # A plain string with no more expansions needs no
+            # further processing, so skip the copy/recursion below.
+            if isinstance(s, str) and '$' not in s:
+                return s
 
-                # Before re-expanding the result, handle
-                # recursive expansion by copying the local
-                # variable dictionary and overwriting a null
-                # string for the value of the variable name
-                # we just expanded.
-                lv = lvars.copy()
-                var = key.partition('.')[0]
-                lv[var] = ''
-                return self.substitute(s, lv)
-        elif is_Sequence(s):
+            # Before re-expanding the result, handle
+            # recursive expansion by copying the local
+            # variable dictionary and overwriting a null
+            # string for the value of the variable name
+            # we just expanded.
+            lv = lvars.copy()
+            var = key.partition('.')[0]
+            lv[var] = ''
+            return self.substitute(s, lv)
+
+        if is_Sequence(s):
+
             def func(l, conv=self.conv, substitute=self.substitute, lvars=lvars):
                 return conv(substitute(l, lvars))
-            return list(map(func, s))
-        elif callable(s):
 
+            return list(map(func, s))
+
+        if callable(s):
             # SCons has the unusual Null class where any __getattr__ call returns it's self,
             # which does not work the signature module, and the Null class returns an empty
             # string if called on, so we make an exception in this condition for Null class
             # Also allow callables where the only non default valued args match the expected defaults
             # this should also allow functools.partial's to work.
             if isinstance(s, SCons.Util.Null) or _callable_matches_subst_args(s):
-
-                s = s(target=lvars['TARGETS'],
-                     source=lvars['SOURCES'],
-                     env=self.env,
-                     for_signature=(self.mode == SUBST_SIG))
+                s = s(
+                    target=lvars['TARGETS'],
+                    source=lvars['SOURCES'],
+                    env=self.env,
+                    for_signature=(self.mode == SUBST_SIG)
+                )
             else:
                 # This probably indicates that it's a callable
                 # object that doesn't match our calling arguments
@@ -479,10 +504,11 @@ class StringSubber:
                     return s
                 s = self.conv(s)
             return self.substitute(s, lvars)
-        elif s is None:
+
+        if s is None:
             return ''
-        else:
-            return s
+
+        return s
 
     def substitute(self, args, lvars):
         """Substitute expansions in an argument or list of arguments.
@@ -490,11 +516,12 @@ class StringSubber:
         This serves as a wrapper for splitting up a string into
         separate tokens.
         """
+
         def sub_match(match):
             return self.conv(self.expand(match.group(1), lvars))
 
         if is_String(args) and not isinstance(args, CmdStringHolder):
-            args = str(args)        # In case it's a UserString.
+            args = str(args)  # In case it's a UserString.
             try:
                 result = _dollar_exps.sub(sub_match, args)
             except TypeError:
@@ -512,9 +539,8 @@ class StringSubber:
                 else:
                     result = ''.join(map(str, result))
             return result
-        else:
-            return self.expand(args, lvars)
 
+        return self.expand(args, lvars)
 
 class ListSubber(UserList):
     """A class to construct the results of a scons_subst_list() call.
@@ -532,6 +558,7 @@ class ListSubber(UserList):
     and the rest of the object takes care of doing the right thing
     internally.
     """
+
     def __init__(self, env, mode: int, conv, gvars: dict) -> None:
         super().__init__([])
         self.env = env
@@ -543,7 +570,7 @@ class ListSubber(UserList):
             self.add_strip = lambda x: self.append(x)
         else:
             self.add_strip = lambda x: None
-        self.in_strip = None
+        self.in_strip = False
         self.next_line()
 
     def expanded(self, s) -> bool:
@@ -578,7 +605,6 @@ class ListSubber(UserList):
         the results of expansions of side-by-side strings still get
         re-evaluated separately, not smushed together.
         """
-
         if is_String(s):
             try:
                 s0, s1 = s[:2]
@@ -604,23 +630,23 @@ class ListSubber(UserList):
                 old_s = s
                 s = None
                 if key in lvars:
-                     s = lvars[key]
+                    s = lvars[key]
                 elif key in self.gvars:
-                     s = self.gvars[key]
+                    s = self.gvars[key]
                 else:
-                     try:
-                         s = eval(key, self.gvars, lvars)
-                     except KeyboardInterrupt:
-                         raise
-                     except Exception as e:
-                         if e.__class__ in AllowableExceptions:
-                             return
-                         raise_exception(e, lvars['TARGETS'], old_s)
+                    try:
+                        s = eval(key, self.gvars, lvars)
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:
+                        if e.__class__ in AllowableExceptions:
+                            return
+                        raise_exception(e, lvars['TARGETS'], old_s)
 
                 if s is None and NameError not in AllowableExceptions:
-                     raise_exception(NameError(key), lvars['TARGETS'], old_s)
+                    raise_exception(NameError(key), lvars['TARGETS'], old_s)
                 elif s is None:
-                     return
+                    return
 
                 # If the string is already full expanded there's no
                 # need to continue recursion.
@@ -650,10 +676,12 @@ class ListSubber(UserList):
             # this should also allow functools.partial's to work.
             if isinstance(s, SCons.Util.Null) or _callable_matches_subst_args(s):
 
-                s = s(target=lvars['TARGETS'],
-                     source=lvars['SOURCES'],
-                     env=self.env,
-                     for_signature=(self.mode == SUBST_SIG))
+                s = s(
+                    target=lvars['TARGETS'],
+                    source=lvars['SOURCES'],
+                    env=self.env,
+                    for_signature=(self.mode == SUBST_SIG)
+                )
             else:
                 # This probably indicates that it's a callable
                 # object that doesn't match our calling arguments
@@ -676,7 +704,7 @@ class ListSubber(UserList):
         """
 
         if is_String(args) and not isinstance(args, CmdStringHolder):
-            args = str(args)        # In case it's a UserString.
+            args = str(args)  # In case it's a UserString.
             args = _separate_args.findall(args)
             for a in args:
                 if a[0] in ' \t\n\r\f\v':
@@ -747,11 +775,11 @@ class ListSubber(UserList):
                     # so we'll take this out but leave it commented
                     # for now in case there's a problem not covered
                     # by the test cases and we need to resurrect this.
-                    #literal1 = self.literal(self[-1][-1])
-                    #literal2 = self.literal(x)
+                    # literal1 = self.literal(self[-1][-1])
+                    # literal2 = self.literal(x)
                     y = self.conv(y)
                     if is_String(y):
-                        #y = CmdStringHolder(y, literal1 or literal2)
+                        # y = CmdStringHolder(y, literal1 or literal2)
                         y = CmdStringHolder(y, literal=False)
                     self[-1][-1] = y
 
@@ -769,18 +797,17 @@ class ListSubber(UserList):
             l = x.is_literal
         except AttributeError:
             return None
-        else:
-            return l()
+        return l()
 
     def open_strip(self, x) -> None:
         """Handle the "open strip" $( token."""
         self.add_strip(x)
-        self.in_strip = 1
+        self.in_strip = True
 
     def close_strip(self, x) -> None:
         """Handle the "close strip" $) token."""
         self.add_strip(x)
-        self.in_strip = None
+        self.in_strip = False
 
 
 # Constants for the "mode" parameter to scons_subst_list() and
@@ -799,7 +826,7 @@ _rm = re.compile(r'\$[()]')
 _rm_split = re.compile(r'(?<!\$)(\$[()])')
 
 # Indexed by the SUBST_* constants above.
-_regex_remove = [ _rm, None, _rm_split ]
+_regex_remove = [_rm, None, _rm_split]
 
 def _rm_list(list):
     return [l for l in list if l not in ('$(', '$)')]
@@ -821,7 +848,7 @@ def _remove_list(list):
     return result
 
 # Indexed by the SUBST_* constants above.
-_list_remove = [ _rm_list, None, _remove_list ]
+_list_remove = [_rm_list, None, _remove_list]
 
 # Regular expressions for splitting strings and handling substitutions,
 # for use by the scons_subst() and scons_subst_list() functions:
@@ -866,7 +893,9 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars=N
     handles separating command lines into lists of arguments, so see
     that function if that's what you're looking for.
     """
-    if (isinstance(strSubst, str) and '$' not in strSubst) or isinstance(strSubst, CmdStringHolder):
+    if (isinstance(strSubst, str) and '$' not in strSubst) or isinstance(
+        strSubst, CmdStringHolder
+    ):
         return strSubst
 
     if gvars is None:
@@ -934,7 +963,7 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars=N
         # This is needed because we now retain $$ instead of
         # replacing them during substition to avoid
         # improperly trying to escape "$$(" as being "$("
-        result = result.replace('$$','$')
+        result = result.replace('$$', '$')
     elif is_Sequence(result):
         remove = _list_remove[mode]
         if remove:
@@ -1014,14 +1043,14 @@ def scons_subst_once(strSubst, env, key):
 
     matchlist = ['$' + key, '${' + key + '}']
     val = env.get(key, '')
+
     def sub_match(match, val=val, matchlist=matchlist):
         a = match.group(1)
         if a in matchlist:
             a = val
         if is_Sequence(a):
             return ' '.join(map(str, a))
-        else:
-            return str(a)
+        return str(a)
 
     if is_Sequence(strSubst):
         result = []
@@ -1038,7 +1067,8 @@ def scons_subst_once(strSubst, env, key):
             else:
                 result.append(arg)
         return result
-    elif is_String(strSubst):
+
+    if is_String(strSubst):
         return _dollar_exps.sub(sub_match, strSubst)
     else:
         return strSubst


### PR DESCRIPTION
* Line breaks added for clarity
* Code-style enforced in some places
* In SpecialAttrWrapper.escape, an attribute is read once and stored in a local variable.
* If all previous parts of an if-else chain have done return (or raise), there's no need for the next to be an "else". This causes one fairly large indentation change in StringSubber.expand(), as about 40 lines shift left one indent (checker observation)
* In subst-dict the local variable is renamed from dict to substitutions to avoid "hiding" built-in dict (frequent checker grumble)

No changed behavior, so existing tests and docs are unchanged.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
