### PR TITLE
Add RequirePackage to the scanned macros for recursive LaTeX scanning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -78,6 +78,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix typos in preface, Chapter 6, Chapter 9 and Chapter 10 of User Guide
     - Fix broken links in Chapter 1 of User Guide
 
+  From Keith F. Prussing:
+    - Add RequiredPackage to the LaTeX scanner for recursive scanning of
+      custom LaTeX packages.
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -102,7 +102,8 @@ long function signature lines, and some linting-inspired cleanups.
 - zip tool now uses zipfile module's "from_file" method to populate ZipInfo
   records, rather than doing manually.
 
-
+- Add RequiredPackage to the LaTeX scanner for recursive scanning of custom
+  LaTeX packages.
 
 PACKAGING
 ---------

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -165,6 +165,7 @@ class LaTeX(ScannerBase):
                      'addsectionbib': 'BIBINPUTS',
                      'makeindex': 'INDEXSTYLE',
                      'usepackage': 'TEXINPUTS',
+                     'RequirePackage': 'TEXINPUTS',
                      'usetheme': 'TEXINPUTS',
                      'usecolortheme': 'TEXINPUTS',
                      'usefonttheme': 'TEXINPUTS',
@@ -193,7 +194,8 @@ class LaTeX(ScannerBase):
               | addbibresource
               | addglobalbib
               | addsectionbib
-              | usepackage
+              | usepackage(?:\s*\[[^\]]+\])?
+              | RequirePackage(?:\s*\[[^\]]+\])?
               | use(?:|color|font|inner|outer)theme(?:\s*\[[^\]]+\])?
               )
                   \s*{([^}]*)}       # first arg
@@ -276,7 +278,7 @@ class LaTeX(ScannerBase):
             base, ext = os.path.splitext( filename )
             if ext == "":
                 return [filename + '.bib']
-        if include_type == 'usepackage':
+        if include_type in ('usepackage', 'RequirePackage'):
             base, ext = os.path.splitext( filename )
             if ext == "":
                 return [filename + '.sty']
@@ -417,7 +419,7 @@ class LaTeX(ScannerBase):
             if n is None:
                 # Do not bother with 'usepackage' warnings, as they most
                 # likely refer to system-level files
-                if inc_type != 'usepackage' or re.match("use(|color|font|inner|outer)theme", inc_type):
+                if inc_type not in ('usepackage', 'RequirePackage') or re.match("use(|color|font|inner|outer)theme", inc_type):
                     SCons.Warnings.warn(
                         SCons.Warnings.DependencyWarning,
                         "No dependency generated for file: %s "

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -101,6 +101,15 @@ test.subdir('subdir2')
 
 test.write(['subdir2', 'inc3.tex'], "\\input{inc2}\n")
 
+test.write('test7.latex',r"""
+\usepackage{scons}
+""")
+test.write('scons.sty',r"""
+\RequirePackage[option]{other}
+\RequirePackage{system}
+""")
+test.write('other.sty', "\n")
+
 # define some helpers:
 #   copied from CTest.py
 class DummyEnvironment(collections.UserDict):
@@ -216,6 +225,15 @@ class LaTeXScannerTestCase6(unittest.TestCase):
              deps_match(self, deps, files_win)
          else:
              deps_match(self, deps, files)
+
+class LaTeXScannerTestCase7(unittest.TestCase):
+     def runTest(self) -> None:
+         env = DummyEnvironment(TEXINPUTS=[test.workpath("subdir")],LATEXSUFFIXES = [".tex", ".ltx", ".latex"])
+         s = SCons.Scanner.LaTeX.LaTeXScanner()
+         path = s.path(env)
+         deps = s(env.File('test7.latex'), env, path)
+         files = ["other.sty", "scons.sty"]
+         deps_match(self, deps, files)
 
 if __name__ == "__main__":
     unittest.main()

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -200,7 +200,7 @@ class LaTeXScannerTestCase5(unittest.TestCase):
                   ('color', 'font', 'inner', 'outer', '')]
          deps_match(self, deps, files)
 
-class LaTeXScannerTestCase5(unittest.TestCase):
+class LaTeXScannerTestCase6(unittest.TestCase):
      def runTest(self) -> None:
          env = DummyEnvironment(TEXINPUTS=[test.workpath("subdir")],LATEXSUFFIXES = [".tex", ".ltx", ".latex"])
          s = SCons.Scanner.LaTeX.LaTeXScanner()


### PR DESCRIPTION
Custom LaTeX packages must use the `\RequirePackage` macro instead of `\updatepackage` used by document authors. If a user has a custom package or style, it needs to be scanned for additional dependencies that may be known by SCons. This adds `\RequirePackage` to the list of macros scanned to ensure proper tracking of dependencies.

Note: This also includes a minor fix in the LaTeXTests.py where a prior PR accidentally reused a class name disabling another test.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
