### PR TITLE
Tweak zipimporter loader sections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -146,6 +146,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       is renamed to "legacy_sched_deprecated".
     - Java tool recognizes all released versions, and no longer needs manual
       updating as new releases are made. Default is now latest LTS - v25.
+    - Clarify internal usage of zipimporter (not user-visible code)
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -117,6 +117,8 @@ long function signature lines, and some linting-inspired cleanups.
 - Java tool recognizes all released versions, and no longer needs manual
   updating as new releases are made. Default is now latest LTS - v25.
 
+- Clarify internal usage of zipimporter (not user-visible code)
+
 PACKAGING
 ---------
 

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -116,15 +116,17 @@ def platform_module(name=platform_default()):
 
                 platform = sys.modules['SCons.Platform'].__path__[0]
                 importer = zipimport.zipimporter(platform)
-                if not hasattr(importer, 'find_spec'):
-                    # zipimport only added find_spec, exec_module in 3.10,
-                    # unlike importlib, where they've been around since 3.4.
-                    # If we don't have 'em, use the old way.
-                    mod = importer.load_module(full_name)
-                else:
+                # TODO: remove this check when Python 3.10 becomes base version
+                if hasattr(importer, 'find_spec'):
+                    # Note zipimporter got these methods later than importlib
                     spec = importer.find_spec(full_name)
                     mod = importlib.util.module_from_spec(spec)
                     importer.exec_module(mod)
+                else:
+                    # Older Pythons. load_module dropped entirely from
+                    # zimpiporter in 3.15, but a new Python won't take this
+                    # branch anyway so it's okay to ignore checker gripes here.
+                    mod = importer.load_module(full_name)
                 sys.modules[full_name] = mod
             except zipimport.ZipImportError:
                 raise SCons.Errors.UserError("No platform named '%s'" % name)

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -263,15 +263,17 @@ class Tool:
 
                 tooldir = sys.modules['SCons.Tool'].__path__[0]
                 importer = zipimport.zipimporter(tooldir)
-                if not hasattr(importer, 'find_spec'):
-                    # zipimport only added find_spec, exec_module in 3.10,
-                    # unlike importlib, where they've been around since 3.4.
-                    # If we don't have 'em, use the old way.
-                    module = importer.load_module(full_name)
-                else:
+                # TODO: remove this check when Python 3.10 becomes base version
+                if hasattr(importer, 'find_spec'):
+                    # Note zipimporter got these methods later than importlib
                     spec = importer.find_spec(full_name)
-                    module = importlib.util.module_from_spec(spec)
-                    importer.exec_module(module)
+                    mod = importlib.util.module_from_spec(spec)
+                    importer.exec_module(mod)
+                else:
+                    # Older Pythons. load_module dropped entirely from
+                    # zimpiporter in 3.15, but a new Python won't take this
+                    # branch anyway so it's okay to ignore checker gripes here.
+                    mod = importer.load_module(full_name)
                 sys.modules[full_name] = module
                 setattr(SCons.Tool, self.name, module)
                 return module

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -580,7 +580,7 @@ class TestSCons(TestCommon):
 
         This method expects a SConscript to be present that will causes
         the warning.  The method writes a SConstruct that calls the
-        SConsscript and looks to see what type of result occurs.
+        SConscript and looks to see what type of result occurs.
 
         The pattern that matches the warning is returned.
 


### PR DESCRIPTION
There's no functional change: flipped the sense of the feature test so the common case is first, and turned the comments into a TODO for Python 3.10 and an explanation of why any possible checker gripe about the fallback isn't actually a problem.

Snuck in the change from withdrawn PR #4872 which is completely unrelated, but wanted to get the 1-char typo fixed (SConsscript -> SConscript in a docstring).

No test or doc impacts (except for the changed comment lines)

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
