### PR TITLE
Fix a doc build niggle

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -146,6 +146,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       is renamed to "legacy_sched_deprecated".
     - Java tool recognizes all released versions, and no longer needs manual
       updating as new releases are made. Default is now latest LTS - v25.
+    - Fixed an old problem in PDF doc generation where the path to an
+      image file ended up with a "not found" error.
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -182,6 +182,9 @@ DOCUMENTATION
 
 * Tweak the wording for $PRINT_CMD_LINE_FUNC.
 
+- Fixed an old problem in PDF doc generation where the path to an
+  image file ended up with a "not found" error.
+
 DEVELOPMENT
 -----------
 

--- a/doc/design/titlepage/SConsBuildBricks_path.svg
+++ b/doc/design/titlepage/SConsBuildBricks_path.svg
@@ -311,7 +311,7 @@
        height="80.018639"
        width="465.43411"
        sodipodi:absref="bricks.jpg"
-       xlink:href="bricks.jpg"
+       xlink:href="titlepage/bricks.jpg"
        x="171.31058"
        y="0.17131744" />
   </g>

--- a/doc/man/titlepage/SConsBuildBricks_path.svg
+++ b/doc/man/titlepage/SConsBuildBricks_path.svg
@@ -311,7 +311,7 @@
        height="80.018639"
        width="465.43411"
        sodipodi:absref="bricks.jpg"
-       xlink:href="bricks.jpg"
+       xlink:href="titlepage/bricks.jpg"
        x="171.31058"
        y="0.17131744" />
   </g>

--- a/doc/reference/titlepage/SConsBuildBricks_path.svg
+++ b/doc/reference/titlepage/SConsBuildBricks_path.svg
@@ -311,7 +311,7 @@
        height="80.018639"
        width="465.43411"
        sodipodi:absref="bricks.jpg"
-       xlink:href="bricks.jpg"
+       xlink:href="titlepage/bricks.jpg"
        x="171.31058"
        y="0.17131744" />
   </g>

--- a/doc/user/titlepage/SConsBuildBricks_path.svg
+++ b/doc/user/titlepage/SConsBuildBricks_path.svg
@@ -311,7 +311,7 @@
        height="80.018639"
        width="465.43411"
        sodipodi:absref="bricks.jpg"
-       xlink:href="bricks.jpg"
+       xlink:href="titlepage/bricks.jpg"
        x="171.31058"
        y="0.17131744" />
   </g>


### PR DESCRIPTION
For a long time, building the PDF versions of docs ended up with an error:
```
[ERROR] FOUserAgent - SVG error: Image not found: file:/home/mats/github/scons/build/doc/user/bricks.jpg <java.io.FileNotFoundException: Image not found: file:/home/mats/github/scons/build/doc/user/bricks.jpg>
java.io.FileNotFoundException: Image not found: file:/home/mats/github/scons/build/doc/user/bricks.jpg
[ERROR] FOUserAgent - SVG graphic could not be built. Reason: org.apache.batik.bridge.BridgeException: file:/home/mats/github/scons/build/doc/user/:0
```
This didn't seem to materially affect the output, but cleaning up the error anyway.

No changes to code or tests, or to any doc contents bar this one href in each of four titlepage files.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
