### PR TITLE
WIP: Update process spawning in platforms

### DIFF
--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1165,11 +1165,17 @@ class CommandActionTestCase(unittest.TestCase):
         env5['ENV']['XYZZY'] = 'xyzzy'
         r = act(target=DummyNode('out5'), source=[], env=env5)
 
+        ENV = {'XYZZY': 'xyzzy5', 'PATH': PATH}
+        if sys.platform == 'win32':
+            # Obscure: on Windows, we fail to initialize Python if SystemRoot
+            # missing (from current support list: versions 3.7-3.10).
+            # The direct assignment to ENV in the Clone call means we don't
+            # retain any of ENV from the cloned environment.
+            ENV['SystemRoot'] = os.environ.get('SystemRoot', "C:\\WINDOWS")
         act = SCons.Action.CommandAction(cmd5)
         r = act(target=DummyNode('out5'),
                 source=[],
-                env=env.Clone(ENV={'XYZZY': 'xyzzy5',
-                                   'PATH': PATH}))
+                env=env.Clone(ENV=ENV))
         assert r == 0
         c = test.read(outfile, 'r')
         assert c == "act.py: 'out5' 'XYZZY'\nact.py: 'xyzzy5'\n", c

--- a/SCons/Platform/Platform.xml
+++ b/SCons/Platform/Platform.xml
@@ -254,11 +254,8 @@ The suffix used for executable file names.
 <summary>
 <para>
 A string naming the shell program that will be passed to the
-&cv-SPAWN;
-function.
-See the
-&cv-SPAWN;
-construction variable for more information.
+command spawner function.
+See the &cv-link-SPAWN; &consvar; for more information.
 </para>
 </summary>
 </cvar>

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -28,8 +28,12 @@ will usually be imported through the generic SCons.Platform.Platform()
 selection method.
 """
 
+from __future__ import annotations
+
 import platform
 import subprocess
+from collections.abc import Callable
+from shlex import quote as escape
 
 from SCons.Platform import TempFileMunge
 from SCons.Platform.virtualenv import ImportVirtualenv
@@ -40,8 +44,17 @@ exitvalmap = {
     13 : 126,
 }
 
-def escape(arg):
-    """escape shell special characters"""
+def old_escape(arg: str) -> str:
+    """Escapes shell special characters.
+
+    This is the default escape function stored in ``env["ESCAPE"]`` for
+    the posix platform, which, if not overridden, is passed to
+    :func:`~SCons.Subst.escape_list` just before a command is spawned,
+    as well to the actual spawner function (as defined by ``env["SPAWN"]``).
+
+    TODO: we're trying to use shlex.quote as the escape function instead.
+      Leave this function around (renamed) until we prove the replacement is valid.
+    """
     slash = '\\'
     special = '"$'
 
@@ -53,33 +66,72 @@ def escape(arg):
     return '"' + arg + '"'
 
 
-def exec_subprocess(l, env):
-    proc = subprocess.Popen(l, env = env, close_fds = True)
-    return proc.wait()
+def spawn(
+    sh: str,
+    escape: Callable[[str], str],
+    cmd: str,
+    args: list[str],
+    env: dict,
+) -> int:
+    """Run command line *args* using shell *sh*.
 
-def subprocess_spawn(sh, escape, cmd, args, env):
-    return exec_subprocess([sh, '-c', ' '.join(args)], env)
+    Arguments:
+      sh: the name of the command to use as the shell
+      escape: a function to quote the produced command line. Ignored.
+      cmd: conventionally, the name of the command, usually taken from
+        the first item of *args*, but since the command is actually a
+        shell, is ignored.
+      args: the argument list representing the command to execute
+      env: the execution environment for the command.
 
-def exec_popen3(l, env, stdout, stderr):
-    proc = subprocess.Popen(l, env = env, close_fds = True,
-                            stdout = stdout,
-                            stderr = stderr)
-    return proc.wait()
+    Returns:
+      the exit code of the command. :py:mod:`subprocess` is explicitly
+      instructed not to raise an exception if the command fails.
+    """
+    cmdargs = [sh, '-c', ' '.join(args)]
+    proc = subprocess.run(cmdargs, env=env, close_fds=True, check=False)
+    return proc.returncode
 
-def piped_env_spawn(sh, escape, cmd, args, env, stdout, stderr):
-    # spawn using Popen3 combined with the env command
-    # the command name and the command's stdout is written to stdout
-    # the command's stderr is written to stderr
-    return exec_popen3([sh, '-c', ' '.join(args)],
-                       env, stdout, stderr)
+
+def piped_spawn(
+    sh: str,
+    escape: Callable[[str], str],
+    cmd: str,
+    args: list[str],
+    env: dict,
+    stdout,  # : Scons.Util.Unbuffered
+    stderr,  # : Scons.Util.Unbuffered
+) -> int:
+    """Run command line *args* using shell *sh*, capturing output.
+
+    Similar to :func:`spawn`, but captures output - this is used by
+    the SConf subsystem when running compile/configure checks, where
+    we specifically need the result data. This ends up handled by
+    a wrapper method :meth:`~SCons.SConf.SConfBase.pspawn_wrapper`.
+
+    Arguments:
+      sh: the name of the command to use as the shell
+      escape: a function to quote the produced command line. Ignored.
+      cmd: conventionally, the name of the command, usually taken from
+        the first item of *args*, but since the command is actually a
+        shell, is ignored.
+      args: the argument list representing the command to execute
+      env: the execution environment for the command.
+      stdout: the place to send the output
+      stderr: the place to send the error output
+
+    Returns:
+      the exit code of the command. :py:mod:`subprocess` is explicitly
+      instructed not to raise an exception if the command fails.
+    """
+    cmdargs = [sh, '-c', ' '.join(args)]
+    proc = subprocess.run(
+        cmdargs, env=env, close_fds=True, stdout=stdout, stderr=stderr, check=False
+    )
+    return proc.returncode
 
 
 def generate(env) -> None:
-    # Bearing in mind we have python 2.4 as a baseline, we can just do this:
-    spawn = subprocess_spawn
-    pspawn = piped_env_spawn
-    # Note that this means that 'escape' is no longer used
-
     if 'ENV' not in env:
         env['ENV']        = {}
     env['ENV']['PATH']    = '/usr/local/bin:/opt/bin:/bin:/usr/bin:/snap/bin'
@@ -98,7 +150,7 @@ def generate(env) -> None:
     env['LIBLITERALPREFIX'] = ''
     env['HOST_OS']        = 'posix'
     env['HOST_ARCH']      = platform.machine()
-    env['PSPAWN']         = pspawn
+    env['PSPAWN']         = piped_spawn
     env['SPAWN']          = spawn
     env['SHELL']          = 'sh'
     env['ESCAPE']         = escape

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -28,13 +28,15 @@ will usually be imported through the generic SCons.Platform.Platform()
 selection method.
 """
 
+from __future__ import annotations
+
 import os
 import os.path
 import platform
+import subprocess
 import sys
-import tempfile
+from collections.abc import Callable
 
-from SCons.Platform.posix import exitvalmap
 from SCons.Platform import TempFileMunge
 from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
@@ -69,146 +71,105 @@ if False:
             "Couldn't override shutil.copy or shutil.copy2 falling back to shutil defaults"
 
 
+def spawn(
+    sh: str,
+    escape: Callable[[str], str],
+    cmd: str,
+    args: list[str],
+    env: dict,
+) -> int:
+    """Run command line *args* using shell *sh*.
 
+    Arguments:
+      sh: the name of the command interpreter (e.g. ``cmd.exe``)
+      escape: a function to quote the command line for the shell.
+        Applied to the joined args string to wrap it in outer quotes
+        required by ``cmd /C`` (see below).
+      cmd: conventionally the command name, but since the actual
+        command is the shell, is ignored.
+      args: the argument list representing the command to execute
+      env: the execution environment for the command.
 
+    Returns:
+      the exit code of the command. :py:mod:`subprocess` is explicitly
+      instructed not to raise an exception if the command fails.
 
-
-
-try:
-    import threading
-    spawn_lock = threading.Lock()
-
-    # This locked version of spawnve works around a Windows
-    # MSVCRT bug, because its spawnve is not thread-safe.
-    # Without this, python can randomly crash while using -jN.
-    # See the python bug at https://github.com/python/cpython/issues/50725
-    # and SCons issue at https://github.com/SCons/scons/issues/2449
-    def spawnve(mode, file, args, env):
-        spawn_lock.acquire()
-        try:
-            if mode == os.P_WAIT:
-                ret = os.spawnve(os.P_NOWAIT, file, args, env)
-            else:
-                ret = os.spawnve(mode, file, args, env)
-        finally:
-            spawn_lock.release()
-        if mode == os.P_WAIT:
-            pid, status = os.waitpid(ret, 0)
-            ret = status >> 8
-        return ret
-except ImportError:
-    # Use the unsafe method of spawnve.
-    # Please, don't try to optimize this try-except block
-    # away by assuming that the threading module is always present.
-    # In the test test/option-j.py we intentionally call SCons with
-    # a fake threading.py that raises an import exception right away,
-    # simulating a non-existent package.
-    def spawnve(mode, file, args, env):
-        return os.spawnve(mode, file, args, env)
-
-# The upshot of all this is that, if you are using Python 1.5.2,
-# you had better have cmd or command.com in your PATH when you run
-# scons.
-
-
-def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
-    # There is no direct way to do that in python. What we do
-    # here should work for most cases:
-    #   In case stdout (stderr) is not redirected to a file,
-    #   we redirect it into a temporary file tmpFileStdout
-    #   (tmpFileStderr) and copy the contents of this file
-    #   to stdout (stderr) given in the argument
-    # Note that because this will paste shell redirection syntax
-    # into the cmdline, we have to call a shell to run the command,
-    # even though that's a bit of a performance hit.
+    ``cmd /C`` Quoting Behavior:
+      When ``cmd /C`` receives a command line whose first character is a
+      double quote, it strips the first and last double-quote characters
+      from the entire line.  ``escape_list`` in Action.py already wraps
+      each individual arg in quotes (via :func:`escape`), so the joined
+      string looks like ``"gcc" "-o" "foo"``.  We must apply ``escape()``
+      again to wrap the whole thing in outer quotes, producing
+      ``""gcc" "-o" "foo""`` — ``cmd /C`` strips the outer pair and
+      passes ``"gcc" "-o" "foo"`` to the program correctly.
+    """
     if not sh:
-        sys.stderr.write("scons: Could not find command interpreter, is it in your PATH?\n")
+        sys.stderr.write(
+            "scons: Could not find command interpreter, is it in your PATH?\n"
+        )
         return 127
-
-    # one temporary file for stdout and stderr
-    tmpFileStdout, tmpFileStdoutName = tempfile.mkstemp(text=True)
-    os.close(tmpFileStdout)  # don't need open until the subproc is done
-    tmpFileStderr, tmpFileStderrName = tempfile.mkstemp(text=True)
-    os.close(tmpFileStderr)
-
-    # check if output is redirected
-    stdoutRedirected = False
-    stderrRedirected = False
-    for arg in args:
-        # are there more possibilities to redirect stdout ?
-        if arg.startswith(">")or arg.startswith("1>"):
-            stdoutRedirected = True
-        # are there more possibilities to redirect stderr ?
-        if arg.startswith("2>"):
-            stderrRedirected = True
-
-    # redirect output of non-redirected streams to our tempfiles
-    if not stdoutRedirected:
-        args.append(">" + tmpFileStdoutName)
-    if not stderrRedirected:
-        args.append("2>" + tmpFileStderrName)
-
-    # actually do the spawn
-    try:
-        args = [sh, '/C', escape(' '.join(args))]
-        ret = spawnve(os.P_WAIT, sh, args, env)
-    except OSError as e:
-        # catch any error
-        try:
-            ret = exitvalmap[e.errno]
-        except KeyError:
-            sys.stderr.write("scons: unknown OSError exception code %d - %s: %s\n" % (e.errno, cmd, e.strerror))
-        if stderr is not None:
-            stderr.write("scons: %s: %s\n" % (cmd, e.strerror))
-
-    # copy child output from tempfiles to our streams
-    # and do clean up stuff
-    if stdout is not None and not stdoutRedirected:
-        try:
-            with open(tmpFileStdoutName, "rb") as tmpFileStdout:
-                output = tmpFileStdout.read()
-                stdout.write(output.decode('oem', "replace").replace("\r\n", "\n"))
-            os.remove(tmpFileStdoutName)
-        except OSError:
-            pass
-
-    if stderr is not None and not stderrRedirected:
-        try:
-            with open(tmpFileStderrName, "rb") as tmpFileStderr:
-                errors = tmpFileStderr.read()
-                stderr.write(errors.decode('oem', "replace").replace("\r\n", "\n"))
-            os.remove(tmpFileStderrName)
-        except OSError:
-            pass
-
-    return ret
+    # Pass a single string to subprocess.run — on Windows, passing a list
+    # causes subprocess to call list2cmdline which adds extra quoting that
+    # breaks cmd /C.
+    cmd_line = f'{sh} /C {escape(" ".join(args))}'
+    proc = subprocess.run(cmd_line, env=env, close_fds=True, check=False)
+    return proc.returncode
 
 
-def exec_spawn(l, env):
-    try:
-        result = spawnve(os.P_WAIT, l[0], l, env)
-    except OSError as e:
-        try:
-            result = exitvalmap[e.errno]
-            sys.stderr.write("scons: %s: %s\n" % (l[0], e.strerror))
-        except KeyError:
-            result = 127
-            if len(l) > 2:
-                if len(l[2]) < 1000:
-                    command = ' '.join(l[0:3])
-                else:
-                    command = l[0]
-            else:
-                command = l[0]
-            sys.stderr.write("scons: unknown OSError exception code %d - '%s': %s\n" % (e.errno, command, e.strerror))
-    return result
+def piped_spawn(
+    sh: str,
+    escape: Callable[[str], str],
+    cmd: str,
+    args: list[str],
+    env: dict,
+    stdout,  # : SCons.Util.Unbuffered
+    stderr,  # : SCons.Util.Unbuffered
+) -> int:
+    """Run command line *args* using shell *sh*, capturing output.
 
+    Similar to :func:`spawn`, but captures stdout and stderr. This is
+    used by the SConf subsystem when running compile/configure checks,
+    where we need the result data. The capture is handled by a wrapper
+    method :meth:`~SCons.SConf.SConfBase.pspawn_wrapper`.
 
-def spawn(sh, escape, cmd, args, env):
+    Arguments:
+      sh: the name of the command interpreter (e.g. ``cmd.exe``)
+      escape: a function to quote the command line for the shell.
+        Applied to the joined args string for ``cmd /C`` (see
+        :func:`spawn`).
+      cmd: conventionally the command name, ignored.
+      args: the argument list representing the command to execute
+      env: the execution environment for the command.
+      stdout: the place to send the output
+      stderr: the place to send the error output
+
+    Returns:
+      the exit code of the command. :py:mod:`subprocess` is explicitly
+      instructed not to raise an exception if the command fails.
+    """
     if not sh:
-        sys.stderr.write("scons: Could not find command interpreter, is it in your PATH?\n")
+        sys.stderr.write(
+            "scons: Could not find command interpreter, is it in your PATH?\n"
+        )
         return 127
-    return exec_spawn([sh, '/C', escape(' '.join(args))], env)
+    # Pass a single string to subprocess.run — see spawn() for details.
+    cmd_line = f'{sh} /C {escape(" ".join(args))}'
+    proc = subprocess.run(
+        cmd_line, env=env, close_fds=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        check=False,
+    )
+    if stdout is not None and proc.stdout:
+        stdout.write(
+            proc.stdout.decode('oem', 'replace').replace('\r\n', '\n')
+        )
+    if stderr is not None and proc.stderr:
+        stderr.write(
+            proc.stderr.decode('oem', 'replace').replace('\r\n', '\n')
+        )
+    return proc.returncode
+
 
 # Windows does not allow special characters in file names anyway, so no
 # need for a complex escape function, we will just quote the arg, except

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -130,10 +130,15 @@ class SpecialAttrWrapper:
     def is_literal(self) -> bool:
         return True
 
+WHITESPACE = " \t\v\f"  # this is less than string.whitespace
+
+def has_whitespace(arg: str) -> bool:
+    """Return true if *arg* contains any whitespace chars."""
+    return any(char in arg for char in WHITESPACE)
+
 def quote_spaces(arg: str) -> str:
-    """Generic function for putting double quotes around any string that
-    has white space in it."""
-    if ' ' in arg or '\t' in arg:
+    """Wraps a string in double quotes if it contains whitespace."""
+    if has_whitespace(arg):
         return f'"{arg}"'
     return str(arg)
 
@@ -171,7 +176,9 @@ class CmdStringHolder(UserString):
         data = self.data
         if self.literal:
             return escape_func(data)
-        if ' ' in data or '\t' in data:
+        if has_whitespace(data):
+            # TODO: if quote_func is quote_spaces, it will do the whitespace
+            #   check as well - is it worth trying to avoid the extra work?
             return quote_func(data)
         return data
 
@@ -682,7 +689,6 @@ class ListSubber(UserList):
             # Also allow callables where the only non default valued args match the expected defaults
             # this should also allow functools.partial's to work.
             if isinstance(s, SCons.Util.Null) or _callable_matches_subst_args(s):
-
                 s = s(
                     target=lvars['TARGETS'],
                     source=lvars['SOURCES'],

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -29,10 +29,20 @@ BuildError exceptions.  Also verify printing the BuildError
 attributes we expect to be most commonly used.
 """
 
+import sys
 import TestSCons
 import re
 
 _python_ = TestSCons._python_
+
+# On Windows, escape() wraps every arg in double quotes.
+# On POSIX, shlex.quote only quotes when the arg contains special chars.
+if sys.platform == 'win32':
+    _f04_cmd = r'"f04" "f04.in"'
+    _f05_cmd = r'"f05" "f05.in"'
+else:
+    _f04_cmd = r'f04 f04.in'
+    _f05_cmd = r'f05 f05.in'
 
 try:
     import threading
@@ -120,7 +130,7 @@ scons: done reading SConscript files.
 scons: Building targets ...
 scons: building terminated because of errors.
 BF: f04 failed (1):  Error 1
-BF:    %(_python_)s myfail.py f03 f04 "f04" "f04.in"
+BF:    %(_python_)s myfail.py f03 f04 %(_f04_cmd)s
 """ % locals()
 
 expect_stderr = """\
@@ -161,9 +171,9 @@ action(["f14"], ["f14.in"])
 action(["f15"], ["f15.in"])
 scons: done building targets (errors occurred during build).
 BF: f04 failed (1):  Error 1
-BF:    %(_python_)s myfail.py f03 f04 "f04" "f04.in"
+BF:    %(_python_)s myfail.py f03 f04 %(_f04_cmd)s
 BF: f05 failed (1):  Error 1
-BF:    %(_python_)s myfail.py f04 f05 "f05" "f05.in"
+BF:    %(_python_)s myfail.py f04 f05 %(_f05_cmd)s
 BF: f07 failed (2):  Source `f07.in' not found, needed by target `f07'.
 BF: f08 failed (2):  My User Error
 BF:    action(["f08"], ["f08.in"])

--- a/test/Java/jar_not_in_PATH.py
+++ b/test/Java/jar_not_in_PATH.py
@@ -38,11 +38,12 @@ test = TestSCons.TestSCons()
 test.file_fixture(['Java-fixture', 'myjar.py'])
 
 test.write('SConstruct', """\
-import os
-
-oldpath = os.environ.get('PATH', '')
 DefaultEnvironment(tools=[])
-env = Environment(ENV={'PATH': ['.']}, tools=['javac', 'jar'])
+env = Environment(tools=[])
+oldpath = env['ENV']['PATH']
+env['ENV']['PATH'] = ['.']
+env.Tool('javac')
+env.Tool('jar')
 env['ENV']['PATH'] = oldpath
 env['JAR'] = r'%(_python_)s myjar.py'
 env.Jar(target='test1.jar', source='test1.class')

--- a/test/Java/rmic_not_in_PATH.py
+++ b/test/Java/rmic_not_in_PATH.py
@@ -39,11 +39,12 @@ test = TestSCons.TestSCons()
 test.file_fixture(['Java-fixture', 'myrmic.py'])
 
 test.write('SConstruct', """
-import os
-
-oldpath = os.environ.get('PATH', '')
 DefaultEnvironment(tools=[])
-env = Environment(ENV={'PATH': ['.']}, tools=['javac', 'rmic'])
+env = Environment(tools=[])
+oldpath = env['ENV']['PATH']
+env['ENV']['PATH'] = ['.']
+env.Tool('javac')
+env.Tool('rmic')
 env['ENV']['PATH'] = oldpath
 env['RMIC'] = r'%(_python_)s myrmic.py'
 env.RMIC(target='outdir', source='test1.java')

--- a/test/builderrors.py
+++ b/test/builderrors.py
@@ -24,6 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
+import sys
 
 import TestSCons
 
@@ -155,6 +156,8 @@ expect = [
     'Permission denied',
     'permission denied',
 ]
+if sys.platform == 'win32':
+    expect.append('The system cannot find the file specified')
 test.must_contain_any_line(test.stderr(), expect)
 
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -794,9 +794,8 @@ if os.name == 'posix':
             arg = f"\"{arg}\""
         return arg
 else:
-    # Windows does not allow special characters in file names
-    # anyway, so no need for an escape function, we will just quote
-    # the arg.
+    # Windows does not allow special characters in file names anyway,
+    # so no need for an escape function - just double-quote the arg.
     def escape(arg):
         if re_space.search(arg):
             arg = f"\"{arg}\""


### PR DESCRIPTION
**Note: this is not ready for inclusion in the currently pending release, it needs more proof. Pushing as a PR so can get a full CI run on it.**


Assisted by AI for the win32 platform module, which is complicated by the fact that switching from `spawnv*` functions to `subprocess` means arguments have to be prepared differently; `subprocess` has a helper function that runs if an argument vector is passed, except it doesn't help our use case because we've already done some quoting work, and stuff would end up with excess quotes.

Default is now simplified functions that just use `subprocess.run()`. On posix, the escape function is now `shlex.quote` from stdlib.  On win32, some funky dances with temporary files are eliminated, as `subprocess` is quite capable of capturing output.

In `Subst.py`, `quote_spaces` is generalized a bit, and a TODO is left in the comments - it doesn't look like `CmdStringHolder.escape` ever gets called with a `quote_func` argument, so the current way is a bit inefficient, but it's unlikely to be a compelling improvement so seems not worth the research to be sure "nothing breaks".

The change of escape function on posix means a couple of places in one test see a change: some arguments that don't need quoting are no longer quoted. Specifically, it's these two former expectations:

```
BF:    %(_python_)s myfail.py f03 f04 "f04" "f04.in"
BF:    %(_python_)s myfail.py f04 f05 "f05" "f05.in"
```

It's possible that the former slightly funky posix quoting was actually to match the win32 output, so tests like this can work with the same output on both flavors.  For now, the test is modified to paste in a platform-specific variable to account for the current difference. The quoting style change is, in a sense, disjoint from the change to use subprocess.

A pretty mysterious error popped up on Windows in three tests, where Python itself failed to launch. All three came from wiping out ENV with a direct assignment - SCons does set up some necessary things in the win32 platform module, but if you throw them away, that work doesn't help. Specifically it turns out that on some Python versions (up to 3.10, not sure what the initial version was), a Windows DLL is queried to setup random number generation, if there's no SystemRoot Windows can't find that DLL and Python fails.  To trigger this the actual executable has to be Python, and SystemRoot has to be missing.  That's now adjusted for in the three tests; there's a remaining question if SCons should backfill the execution env in these cases. It's an obscure situation, but the failure mode is particularly unhelpful to an SCons developer (or, more likely, test writer).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
