### PR TITLE
Prefer clang over gcc on FreeBSD and OpenBSD

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
+  From Vassili Tchersky:
+    - Add 'bsd' platform definition.
+    - The default tool search order now prefers the LLVM/clang toolchain
+      over GCC on FreeBSD and OpenBSD (PR #4887).
+
   From Cornelii Sandberg:
     - Fix Variables() not reading a saved-variables file (e.g. custom.py)
       from the source directory when building in a separate variant

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -47,6 +47,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- The tool search order now prefers clang over gcc on FreeBSD and OpenBSD.
+
 FIXES
 -----
 

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -84,6 +84,8 @@ def platform_default():
             return 'aix'
         elif 'darwin' in sys.platform:
             return 'darwin'
+        elif sys.platform.startswith(('freebsd', 'openbsd')):
+            return 'bsd'
         else:
             return 'posix'
     elif os.name == 'os2':

--- a/SCons/Platform/bsd.py
+++ b/SCons/Platform/bsd.py
@@ -1,0 +1,35 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Platform-specific initialisation for BSD flavours whose base system
+ships an LLVM toolchain.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
+
+from . import posix
+
+def generate(env) -> None:
+    posix.generate(env)

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -827,6 +827,14 @@ def tool_list(platform, env):
         assemblers = ['gas', 'nasm', 'masm']
         fortran_compilers = ['gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
         ars = ['ar', 'mslib']
+    elif str(platform) == 'bsd':
+        "prefer Clang tools on the BSDs whose base toolchain is LLVM"
+        linkers = ['gnulink', 'ilink']
+        c_compilers = ['clang', 'gcc', 'intelc', 'icc', 'cc']
+        cxx_compilers = ['clang++', 'g++', 'intelc', 'icc', 'cxx']
+        assemblers = ['gas', 'nasm', 'masm']
+        fortran_compilers = ['gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
+        ars = ['ar', ]
     else:
         "prefer GNU tools on all other platforms"
         linkers = ['gnulink', 'ilink']

--- a/SCons/Tool/default.xml
+++ b/SCons/Tool/default.xml
@@ -118,6 +118,18 @@ It also selects all found from the list
 </para>
 
 <para>
+On the BSD systems whose base compiler is LLVM/clang
+(FreeBSD and OpenBSD), the default tools list matches
+the Linux one except that the C compiler is selected
+(first-found) from
+&t-link-clang;, &t-link-gcc;, &t-link-intelc;, &t-link-icc;,
+&t-link-cc;
+and the C++ compiler from
+&t-link-clangxx;, &t-link-gXX;, &t-link-intelc;, &t-link-icc;,
+&t-link-cXX;.
+</para>
+
+<para>
 Default lists for other platforms can be found by
 examining the &scons;
 source code (see

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -482,6 +482,12 @@ On SGI IRIX, IBM AIX, Hewlett Packard HP-UX, and Oracle Solaris systems,
 searches for the native compiler tools
 (MIPSpro, Visual Age, aCC, and Forte tools respectively)
 and the GCC tool chain.
+On FreeBSD and OpenBSD,
+&scons;
+searches in order
+for the LLVM/clang tools,
+the GCC tool chain,
+and the Intel compiler tools.
 On all other platforms,
 including POSIX (Linux and UNIX) and macOS platforms,
 &scons;


### PR DESCRIPTION
Those platforms ships Clang in their base system.

GCC is somehow [supported](https://www.freebsd.org/status/report-2025-07-2025-09/gcc/), but lag behind.

For the record, to test on FreeBSD, I had to:
- install `py312-build` and `py312-setuptools`,
- install package `gmake` and change all hard-coded occurences of 'make' to 'gmake' (SCons does not support $MAKE convention).
- install `py312-sphinx-book-theme` and `py312-pillow` (for rst2pdf, required even if the build log shows `SKIP_PDF=1`).

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
