### PR TITLE
Handle missing mslink manifest better

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -151,6 +151,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       image file ended up with a "not found" error.
     - Fixed PDF doc build problems relating to illegal margin widths ("")
       and table column alignment.
+    - Handle missing/malformed manifest in mslink more gracefully (issue 4866).
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -119,6 +119,8 @@ long function signature lines, and some linting-inspired cleanups.
 
 - Clarify internal usage of zipimporter (not user-visible code)
 
+- Handle missing/malformed manifest in mslink more gracefully (issue 4866).
+
 PACKAGING
 ---------
 

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -304,11 +304,8 @@ def generate(env) -> None:
     env['MT'] = 'mt'
     # env['MTFLAGS'] = ['-hashupdate']
     env['MTFLAGS'] = SCons.Util.CLVar('/nologo')
-    # Note: use - here to prevent build failure if no manifest produced.
-    # This seems much simpler than a fancy system using a function action to see
-    # if the manifest actually exists before trying to run mt with it.
-    env['MTEXECOM'] = '-$MT $MTFLAGS -manifest ${TARGET}.manifest $_MANIFEST_SOURCES -outputresource:$TARGET;1'
-    env['MTSHLIBCOM'] = '-$MT $MTFLAGS -manifest ${TARGET}.manifest $_MANIFEST_SOURCES -outputresource:$TARGET;2'
+    env['MTEXECOM'] = '$MT $MTFLAGS -manifest ${TARGET}.manifest $_MANIFEST_SOURCES -outputresource:$TARGET;1'
+    env['MTSHLIBCOM'] = '$MT $MTFLAGS -manifest ${TARGET}.manifest $_MANIFEST_SOURCES -outputresource:$TARGET;2'
     # TODO Future work garyo 27-Feb-11
     env['_MANIFEST_SOURCES'] = None  # _windowsManifestSources
 


### PR DESCRIPTION
`MTEXECOM` and `MTSHLIBCOM` no longer default to having a dash prefix, which means to ignore failure result.  The settings of these two variables came with a comment that appears outdated, as `mslink.py` now has `embedManifestDllCheck` and `embedManifestExeCheck`, which do existence checks for the manifest, so we won't fall in the hole the comment suggests we're trying to avoid.

Without this change, we don't detect an error due to malformed inputs, and end up with a link target that's unusable.

Fixes #4866

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
