### PR TITLE
Fix $SHDLINKCOM for ldc D variant

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -155,8 +155,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed PDF doc build problems relating to illegal margin widths ("")
       and table column alignment.
     - Handle missing/malformed manifest in mslink more gracefully (issue 4866).
-    - Change default D compiler (ldc variant) link line to account for
-      upstream library naming convention change.
+    - Change the way ldc D compiler specifies including libdruntime when making
+      a shared object. ldc version 1.3 (2017) introduced shared druntime on some
+      platforms, with an odd library naming scheme. SCons specification was
+      "too precise" to work cross-platform with the new scheme, let the linker
+      pass pick.
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -155,6 +155,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed PDF doc build problems relating to illegal margin widths ("")
       and table column alignment.
     - Handle missing/malformed manifest in mslink more gracefully (issue 4866).
+    - Change default D compiler (ldc variant) link line to account for
+      upstream library naming convention change.
     - Reference manual improvements:
       * More clarifications in Builder Methods section.
       * Clarify VariantDir behavior when switching from duplicate=True (the

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -123,6 +123,15 @@ long function signature lines, and some linting-inspired cleanups.
 
 - Handle missing/malformed manifest in mslink more gracefully (issue 4866).
 
+- Default D compiler (ldc variant) shared object link line $SHDLINKCOM now
+  references libary "druntime-ldc-shared" to reflect how libraries are
+  currently named (shared and debug variants have those tags in the name).
+  If this causes problems with a library not found, set $SHDLINKCOM back
+  to not using the -shared part. In systems available for our testing, the
+  old way was linking against the static library despite the variable being
+  specifically intended to select the shared library.
+  No change to the other two D variants (dmd and gdc).
+
 PACKAGING
 ---------
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -123,14 +123,12 @@ long function signature lines, and some linting-inspired cleanups.
 
 - Handle missing/malformed manifest in mslink more gracefully (issue 4866).
 
-- Default D compiler (ldc variant) shared object link line $SHDLINKCOM now
-  references libary "druntime-ldc-shared" to reflect how libraries are
-  currently named (shared and debug variants have those tags in the name).
-  If this causes problems with a library not found, set $SHDLINKCOM back
-  to not using the -shared part. In systems available for our testing, the
-  old way was linking against the static library despite the variable being
-  specifically intended to select the shared library.
-  No change to the other two D variants (dmd and gdc).
+- Change the way ldc D compiler specifies including libdruntime when
+  making a shared object. ldc version 1.3 (2017) introduced shared
+  druntime on some platforms, with an odd library naming scheme. SCons
+  specification was "too precise" to work cross-platform with the new
+  scheme, now let the linker pass pick. Adjust $SHDLINKFLAGS to change this,
+  or choose other schemes, such as LTO libs.
 
 PACKAGING
 ---------

--- a/SCons/Tool/DCommon.xml
+++ b/SCons/Tool/DCommon.xml
@@ -28,6 +28,12 @@ This file is processed by the bin/SConsDoc.py module.
 <summary>
 <para>
 The D compiler to use.
+&SCons; provides tool modules for three D compilation systems:
+DMD (&t-link-dmd;), the reference compiler;
+LDC (&t-link-ldc;), the LLVM-based D compiler;
+and GDC (&t-link-gdc;), from the GNU Compiler Collection,
+searched in that order.
+Use a tool specifier if you need to prefer a specific compiler.
 See also &cv-link-SHDC; for compiling to shared objects.
 </para>
 </summary>
@@ -58,7 +64,7 @@ See also &cv-link-SHDCOMSTR; for compiling to shared objects.
 <cvar name="DDEBUG">
 <summary>
 <para>
-List of debug tags to enable when compiling.
+Debug tags to enable when compiling.
 </para>
 </summary>
 </cvar>
@@ -66,7 +72,7 @@ List of debug tags to enable when compiling.
 <cvar name="DDEBUGPREFIX">
 <summary>
 <para>
-DDEBUGPREFIX.
+Command-line prefix for debug tags.
 </para>
 </summary>
 </cvar>
@@ -74,7 +80,7 @@ DDEBUGPREFIX.
 <cvar name="DDEBUGSUFFIX">
 <summary>
 <para>
-DDEBUGSUFFIX.
+Command-line suffix for debug tags.
 </para>
 </summary>
 </cvar>
@@ -82,7 +88,7 @@ DDEBUGSUFFIX.
 <cvar name="DFILESUFFIX">
 <summary>
 <para>
-DFILESUFFIX.
+The suffix that indicates a D source file.
 </para>
 </summary>
 </cvar>
@@ -90,7 +96,7 @@ DFILESUFFIX.
 <cvar name="DFLAGPREFIX">
 <summary>
 <para>
-DFLAGPREFIX.
+The command-line prefix for D compiler flags.
 </para>
 </summary>
 </cvar>
@@ -106,7 +112,7 @@ General options that are passed to the D compiler.
 <cvar name="DFLAGSUFFIX">
 <summary>
 <para>
-DFLAGSUFFIX.
+The command-line suffix for D compiler flags.
 </para>
 </summary>
 </cvar>
@@ -114,7 +120,7 @@ DFLAGSUFFIX.
 <cvar name="DINCSUFFIX">
 <summary>
 <para>
-DLIBFLAGSUFFIX.
+The command-line suffix for D include file directories.
 </para>
 </summary>
 </cvar>
@@ -122,7 +128,7 @@ DLIBFLAGSUFFIX.
 <cvar name="DINCPREFIX">
 <summary>
 <para>
-DINCPREFIX.
+The command-line prefix for D include file directories.
 </para>
 </summary>
 </cvar>
@@ -130,7 +136,7 @@ DINCPREFIX.
 <cvar name="DLIB">
 <summary>
 <para>
-Name of the lib tool to use for D codes.
+Name of the lib tool to use for D code.
 </para>
 </summary>
 </cvar>
@@ -146,7 +152,7 @@ The command line to use when creating libraries.
 <cvar name="DLIBDIRPREFIX">
 <summary>
 <para>
-DLIBLINKPREFIX.
+The command-line prefix for D library directories.
 </para>
 </summary>
 </cvar>
@@ -154,7 +160,7 @@ DLIBLINKPREFIX.
 <cvar name="DLIBDIRSUFFIX">
 <summary>
 <para>
-DLIBLINKSUFFIX.
+The command-line suffix for D library directories.
 </para>
 </summary>
 </cvar>
@@ -212,7 +218,7 @@ See also &cv-link-SHDLINKCOM; for linking shared objects.
 <cvar name="DLINKFLAGS">
 <summary>
 <para>
-List of linker flags.
+Linker flags.
 See also &cv-link-SHDLINKFLAGS; for linking shared objects.
 </para>
 </summary>
@@ -261,7 +267,7 @@ DRPATHSUFFIX.
 <cvar name="DVERPREFIX">
 <summary>
 <para>
-DVERPREFIX.
+Command-line prefix for version tag.
 </para>
 </summary>
 </cvar>
@@ -277,7 +283,7 @@ List of version tags to enable when compiling.
 <cvar name="DVERSUFFIX">
 <summary>
 <para>
-DVERSUFFIX.
+Command-line suffix for version tag.
 </para>
 </summary>
 </cvar>
@@ -345,7 +351,7 @@ See also &cv-link-DLINKCOM; for linking static objects.
 <cvar name="SHDLINKFLAGS">
 <summary>
 <para>
-The list of flags to use when generating a shared object.
+The flags to use when generating a shared object for the D language.
 See also &cv-link-DLINKFLAGS; for linking static objects.
 </para>
 </summary>

--- a/SCons/Tool/DCommon.xml
+++ b/SCons/Tool/DCommon.xml
@@ -44,8 +44,11 @@ See also &cv-link-SHDC; for compiling to shared objects.
 <para>
 The command line used to compile a D file to an object file.
 Any options specified in the &cv-link-DFLAGS; construction variable
-is included on this command line.
+are included on this command line.
 See also &cv-link-SHDCOM; for compiling to shared objects.
+See also the &b-link-ProgramAllAtOnce; builder
+for how to compile directly to an executable without
+making intermediate object files.
 </para>
 </summary>
 </cvar>
@@ -54,7 +57,7 @@ See also &cv-link-SHDCOM; for compiling to shared objects.
 <summary>
 <para>
 If set, the string displayed when a D source file
-is compiled to a (static) object file.
+is compiled to an object file.
 If not set, then &cv-link-DCOM; (the command line) is displayed.
 See also &cv-link-SHDCOMSTR; for compiling to shared objects.
 </para>
@@ -72,7 +75,8 @@ Debug tags to enable when compiling.
 <cvar name="DDEBUGPREFIX">
 <summary>
 <para>
-Command-line prefix for debug tags.
+Prefix used for debug tags from &cv-link-DDEBUG;.
+Defaults vary by D compiler.
 </para>
 </summary>
 </cvar>
@@ -80,7 +84,7 @@ Command-line prefix for debug tags.
 <cvar name="DDEBUGSUFFIX">
 <summary>
 <para>
-Command-line suffix for debug tags.
+Suffix used for debug tags from &cv-link-DDEBUG;.
 </para>
 </summary>
 </cvar>
@@ -88,7 +92,8 @@ Command-line suffix for debug tags.
 <cvar name="DFILESUFFIX">
 <summary>
 <para>
-The suffix that indicates a D source file.
+File suffix for D source files.
+The default is <literal>.d</literal>.
 </para>
 </summary>
 </cvar>
@@ -96,7 +101,7 @@ The suffix that indicates a D source file.
 <cvar name="DFLAGPREFIX">
 <summary>
 <para>
-The command-line prefix for D compiler flags.
+Prefix added to each element of &cv-link-DFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -112,7 +117,7 @@ General options that are passed to the D compiler.
 <cvar name="DFLAGSUFFIX">
 <summary>
 <para>
-The command-line suffix for D compiler flags.
+Suffix added to each element of &cv-link-DFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -120,7 +125,7 @@ The command-line suffix for D compiler flags.
 <cvar name="DINCSUFFIX">
 <summary>
 <para>
-The command-line suffix for D include file directories.
+Suffix added to each path in &cv-link-DPATH;.
 </para>
 </summary>
 </cvar>
@@ -128,7 +133,7 @@ The command-line suffix for D include file directories.
 <cvar name="DINCPREFIX">
 <summary>
 <para>
-The command-line prefix for D include file directories.
+Prefix added to each path in &cv-link-DPATH;.
 </para>
 </summary>
 </cvar>
@@ -136,7 +141,7 @@ The command-line prefix for D include file directories.
 <cvar name="DLIB">
 <summary>
 <para>
-Name of the lib tool to use for D code.
+Name of the static library tool for D code.
 </para>
 </summary>
 </cvar>
@@ -144,7 +149,15 @@ Name of the lib tool to use for D code.
 <cvar name="DLIBCOM">
 <summary>
 <para>
-The command line to use when creating libraries.
+The command line to use when linking a static library.
+</para>
+</summary>
+</cvar>
+
+<cvar name="DLIBFLAGS">
+<summary>
+<para>
+The flags to pass to the library tool.
 </para>
 </summary>
 </cvar>
@@ -152,7 +165,8 @@ The command line to use when creating libraries.
 <cvar name="DLIBDIRPREFIX">
 <summary>
 <para>
-The command-line prefix for D library directories.
+The command-line prefix for library search directories
+from &cv-link-LIBPATH; when linking D code.
 </para>
 </summary>
 </cvar>
@@ -160,7 +174,8 @@ The command-line prefix for D library directories.
 <cvar name="DLIBDIRSUFFIX">
 <summary>
 <para>
-The command-line suffix for D library directories.
+The command-line suffix for library search directories
+from &cv-link-LIBPATH; when linking D code.
 </para>
 </summary>
 </cvar>
@@ -168,7 +183,7 @@ The command-line suffix for D library directories.
 <cvar name="DLIBFLAGSUFFIX">
 <summary>
 <para>
-DLIBFLAGSUFFIX.
+Suffix added to each element of &cv-link-DLIBFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -176,7 +191,7 @@ DLIBFLAGSUFFIX.
 <cvar name="DLIBFLAGPREFIX">
 <summary>
 <para>
-DLIBFLAGPREFIX.
+Prefix added to each element of &cv-link-DLIBFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -184,7 +199,7 @@ DLIBFLAGPREFIX.
 <cvar name="DLIBLINKPREFIX">
 <summary>
 <para>
-DLIBLINKPREFIX.
+Prefix added to each library name from &cv-link-LIBS;.
 </para>
 </summary>
 </cvar>
@@ -192,7 +207,7 @@ DLIBLINKPREFIX.
 <cvar name="DLIBLINKSUFFIX">
 <summary>
 <para>
-DLIBLINKSUFFIX.
+Suffix added to each library name from &cv-link-LIBS;.
 </para>
 </summary>
 </cvar>
@@ -227,7 +242,7 @@ See also &cv-link-SHDLINKFLAGS; for linking shared objects.
 <cvar name="DLINKFLAGSUFFIX">
 <summary>
 <para>
-DLINKFLAGSUFFIX.
+Suffix added to each element of &cv-link-DLINKFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -235,7 +250,7 @@ DLINKFLAGSUFFIX.
 <cvar name="DLINKFLAGPREFIX">
 <summary>
 <para>
-DLINKFLAGPREFIX.
+Prefix added to each element of &cv-link-DLINKFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -251,7 +266,7 @@ DLINKFLAGPREFIX.
 <cvar name="DRPATHPREFIX">
 <summary>
 <para>
-DRPATHPREFIX.
+Prefix added to rpath entries when generating shared objects.
 </para>
 </summary>
 </cvar>
@@ -259,7 +274,7 @@ DRPATHPREFIX.
 <cvar name="DRPATHSUFFIX">
 <summary>
 <para>
-DRPATHSUFFIX.
+Suffix added to rpath entries when generating shared objects.
 </para>
 </summary>
 </cvar>
@@ -267,7 +282,7 @@ DRPATHSUFFIX.
 <cvar name="DVERPREFIX">
 <summary>
 <para>
-Command-line prefix for version tag.
+Prefix added to each element of &cv-link-DVERSIONS;.
 </para>
 </summary>
 </cvar>
@@ -283,7 +298,7 @@ List of version tags to enable when compiling.
 <cvar name="DVERSUFFIX">
 <summary>
 <para>
-Command-line suffix for version tag.
+Suffix added to each element of &cv-link-DVERSIONS;.
 </para>
 </summary>
 </cvar>
@@ -332,8 +347,7 @@ set.
 <cvar name="SHDLINK">
 <summary>
 <para>
-The linker to use when creating shared objects for code bases
-include D sources.
+The linker to use when creating shared objects from dlang code.
 See also &cv-link-DLINK; for linking static objects.
 </para>
 </summary>
@@ -360,7 +374,9 @@ See also &cv-link-DLINKFLAGS; for linking static objects.
 <cvar name="DI_FILE_SUFFIX">
 <summary>
 <para>
-Suffix of d include files default is .di
+Suffix for D interface files,
+which are translations of C header files.
+The default is <literal>.di</literal>.
 </para>
 </summary>
 </cvar>
@@ -368,7 +384,8 @@ Suffix of d include files default is .di
 <cvar name="DI_FILE_DIR">
 <summary>
 <para>
-Path where .di files will be generated
+Path to search for D interface files,
+which are translations of C header files.
 </para>
 </summary>
 </cvar>
@@ -376,7 +393,8 @@ Path where .di files will be generated
 <cvar name="DI_FILE_DIR_PREFIX">
 <summary>
 <para>
-Prefix to send the di path argument to compiler
+Prefix added to the name of the D interface file
+directory from &cv-link-DI_FILE_DIR;.
 </para>
 </summary>
 </cvar>
@@ -384,7 +402,8 @@ Prefix to send the di path argument to compiler
 <cvar name="DI_FILE_DIR_SUFFFIX">
 <summary>
 <para>
-Suffix to send the di path argument to compiler
+Suffix added to the name of the D interface file
+directory from &cv-link-DI_FILE_DIR;.
 </para>
 </summary>
 </cvar>
@@ -397,7 +416,8 @@ Suffix to send the di path argument to compiler
   </para>
   <para>
     D sources can be compiled file-by-file as C and C++ source are, and
-    D is integrated into the &scons; Object and Program builders for
+    D is integrated into the &scons;
+    &b-link-Object; and &b-link-Program; builders for
     this model of build. D codes can though do whole source
     meta-programming (some of the testing frameworks do this). For this
     it is imperative that all sources are compiled and linked in a single

--- a/SCons/Tool/ldc.py
+++ b/SCons/Tool/ldc.py
@@ -108,9 +108,8 @@ def generate(env) -> None:
     env['DLINKCOM'] = '$DLINK -of=$TARGET $DLINKFLAGS $__DRPATH $SOURCES $_DLIBDIRFLAGS $_DLIBFLAGS'
 
     env['SHDLINK'] = '$DC'
-    env['SHDLINKFLAGS'] = SCons.Util.CLVar('$DLINKFLAGS -shared -defaultlib=phobos2-ldc')
-
-    env['SHDLINKCOM'] = '$DLINK -of=$TARGET $SHDLINKFLAGS $__SHDLIBVERSIONFLAGS $__DRPATH $SOURCES $_DLIBDIRFLAGS $_DLIBFLAGS -L-ldruntime-ldc-shared'
+    env['SHDLINKFLAGS'] = SCons.Util.CLVar('$DLINKFLAGS -shared -defaultlib=phobos2-ldc,druntime-ldc')
+    env['SHDLINKCOM'] = '$DLINK -of=$TARGET $SHDLINKFLAGS $__SHDLIBVERSIONFLAGS $__DRPATH $SOURCES $_DLIBDIRFLAGS $_DLIBFLAGS'
 
     env['DLIBLINKPREFIX'] = '' if env['PLATFORM'] == 'win32' else '-L-l'
     env['DLIBLINKSUFFIX'] = '.lib' if env['PLATFORM'] == 'win32' else ''

--- a/SCons/Tool/ldc.py
+++ b/SCons/Tool/ldc.py
@@ -110,7 +110,7 @@ def generate(env) -> None:
     env['SHDLINK'] = '$DC'
     env['SHDLINKFLAGS'] = SCons.Util.CLVar('$DLINKFLAGS -shared -defaultlib=phobos2-ldc')
 
-    env['SHDLINKCOM'] = '$DLINK -of=$TARGET $SHDLINKFLAGS $__SHDLIBVERSIONFLAGS $__DRPATH $SOURCES $_DLIBDIRFLAGS $_DLIBFLAGS -L-ldruntime-ldc'
+    env['SHDLINKCOM'] = '$DLINK -of=$TARGET $SHDLINKFLAGS $__SHDLIBVERSIONFLAGS $__DRPATH $SOURCES $_DLIBDIRFLAGS $_DLIBFLAGS -L-ldruntime-ldc-shared'
 
     env['DLIBLINKPREFIX'] = '' if env['PLATFORM'] == 'win32' else '-L-l'
     env['DLIBLINKSUFFIX'] = '.lib' if env['PLATFORM'] == 'win32' else ''

--- a/test/D/Scanner.py
+++ b/test/D/Scanner.py
@@ -39,8 +39,10 @@ test = TestSCons.TestSCons()
 
 _obj = TestSCons._obj
 
+# Why is this test limited to only 'dmd'?
+# It's been tested to work with the other two compilers and no dmd...
 if not isExecutableOfToolAvailable(test, 'dmd'):
-    test.skip_test("Could not find 'dmd'; skipping test.\n")
+   test.skip_test("Could not find 'dmd'; skipping test.\n")
 
 test.subdir(['p'])
 


### PR DESCRIPTION
[Description updated]

The ldc (llvm D compiler) project introduced shared base libraries in release 1.3.0 "for platforms that support it", which includes Linux and Mac but not Windows. This took place in mid-2017, so nine years ago - but postdates our support for D. When they did so they introduced a naming convention: a shared library will include `-shared` in the name, and a debug build will include `-debug` in the name (these can be combined). For the case of `$SHDLINKCOM` - the command line to link a shared object from D files, we had been adding the `druntime-ldc` library with a `-L` linker flag, while `phobos2-ldc` was added in `$SHDLINKFLAGS`. The approach used for druntime is a more precise match, and in fact led to the static archive of druntime being linked on Linux/Mac.

Here's a typical Linux library list directly from upstream (GitHub release of latest, 1.42.0):
```
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc.a
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-debug.a
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-debug-shared.so
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-debug-shared.so.112
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-debug-shared.so.112.1
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-lto.a
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-shared.so
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-shared.so.112
ldc2-1.42.0-linux-x86_64/lib/libdruntime-ldc-shared.so.112.1
```

Once certain distros stopped packaging the static archives (e.g. Fedora), `druntime-ldc` has nothing to match any longer, since there's no library with that *precise* name and the `lib` prefix.

It turns out there's a better way: ldc2 has a way to tell it the libraries to include, and when done this way, it takes care of the naming convention - this is already the way the phobos library was specified, so just adding druntime there and pulling it out of `$SHDLINKCOM`.  There may be some reasoning for the way it was being done, but I haven't discovered it.  Users who don't like this approach can always tweak their construction variables, but this appears to be the "most portable" approach we can take (and also doesn't break Windows, which has no `-shared` variants:
```
ldc2-1.3.0-win64-msvc/lib64/druntime-ldc-debug.lib
ldc2-1.3.0-win64-msvc/lib64/druntime-ldc.lib
```

No actual test changes. Docs were tweaked a little - they now mention the three different D compilers in a hopefully visible place, and the D construction variables now all say something (quite a few were just placeholders where the description was the name of the variable).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
