### PR TITLE
Add initial support for `ty` type hinting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ NOTE: The last release to support Python 3.7 or Python 3.8 is 4.11.0.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Thaddeus Crews:
+    - ty: Initial support setup within `pyproject.toml`.
+
   From Mats Wichmann:
     - Undo, for now, the 4.11.0 change (from PR 4875) to read a
       saved-Variables file using a File node. There were unanticipated

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -63,7 +63,9 @@ DOCUMENTATION
 DEVELOPMENT
 -----------
 
-- List visible changes in the way SCons is developed
+- List visible changes in the way SCons is 
+
+- ty: Initial support setup within `pyproject.toml`.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,4 +139,13 @@ exclude = [
     "^SCons/Tool/docbook/docbook-xsl-1.76.1/",
 ]
 
+[tool.ty.environment]
+python-version = "3.9"
+python-platform = "all"
+extra-paths = ["./testing/framework"]
+
+[tool.ty.rules]
+blanket-ignore-comment = "warn"
+missing-type-argument = "warn"
+
 # TODO: need a matching section for pyright? (doesn't read [tool.mypy]


### PR DESCRIPTION
A minimal baseline for utilizing `ty` as a type hinting tool within the codebase. This has technically already been possible, but a few key settings added to `pyproject.toml` help clean things up even further:

- Specify our (upcoming) 3.9 minimum.
- Don't assume a specific platform in intellisense; will try to support any/all.
- Pass "./testing/framework" as a module path to cleanup the overwhelming majority of error noise.
- Add explicit warnings for 2 default-ignored rules (`blanket-ignore-commen` & `missing-type-argument`), as the areas of the engine with type hints already have these accounted for.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
