### PR TITLE
Fix documentation processing for lxml 6.1.3 and newer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - ty: Initial support setup within `pyproject.toml`.
     - Removed Python 3.7 & 3.8 support.
 
+  From William Deegan:
+    - Fix documentation processing to work with lxml 6.1.3 and newer, which no
+      longer resolves external parameter entities by default (lxml LP#2165901).
+      This affects both the SCons documentation build and the docbook tool,
+      which failed on any DocBook source pulling in an external entity module.
+
   From Mats Wichmann:
     - Reference manual improvements:
       * Additional clarification for SideEffect()

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       longer resolves external parameter entities by default (lxml LP#2165901).
       This affects both the SCons documentation build and the docbook tool,
       which failed on any DocBook source pulling in an external entity module.
+    - Fix the DocBook slides tests on distributions whose docbook-xsl VERSION
+      file carries a non-numeric <fm:Version> - Debian and Ubuntu ship
+      "snapshot" there for 1.79.2. detectXsltVersion() reported (0, 0, 0), so
+      the tests fed the plain, non-namespaced input to namespace-aware
+      stylesheets and silently produced an empty document. The helper now
+      falls back to the <fm:Branch> field, which names the XSL-NS branch
+      outright.
 
   From Mats Wichmann:
     - Reference manual improvements:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -74,6 +74,12 @@ DEVELOPMENT
 
 - ty: Initial support setup within `pyproject.toml`.
 
+- The DocBook slides tests now pass on Debian and Ubuntu, whose docbook-xsl
+  package writes "snapshot" instead of a number in the stylesheets' VERSION
+  file. The test helper read that as version (0, 0, 0) and so handed the
+  plain, non-namespaced input to namespace-aware stylesheets, which quietly
+  produced an empty document; it now falls back to the <fm:Branch> field.
+
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -41,6 +41,11 @@ FIXES
 
 - Fix ninja to honor AlwaysBuild on a target
 
+- Fix documentation processing to work with lxml 6.1.3 and newer, which no
+  longer resolves external parameter entities by default. This affects both
+  the SCons documentation build and the docbook tool, which failed on any
+  DocBook source pulling in an external entity module.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -75,6 +75,32 @@ if has_lxml and lmxl_xslt_global_max_depth:
 #
 # Helper functions
 #
+def _make_xml_parser():
+    """Return an XML parser set up to resolve external entities.
+
+    As of lxml 6.1.3 external *parameter* entities are no longer resolved
+    unless asked for explicitly (see
+    https://bugs.launchpad.net/lxml/+bug/2165901), which breaks DocBook sources
+    that pull in their entity definitions with a construct like::
+
+        <!ENTITY % myents SYSTEM "entities.mod">
+        %myents;
+
+    resolve_entities=True is spelled as a bool on purpose: the string forms
+    ("internal"/"always") only exist from lxml 6.0 on, while the bool is
+    accepted by every version we support.
+
+    load_dtd stays False on purpose as well. It controls loading the *external*
+    DTD subset - the internal subset holding the entity declarations above is
+    read either way - and turning it on makes libxml2 try to fetch the remote
+    DTD of any document declaring one (as DocBook documents commonly do), which
+    no_network then refuses.
+    """
+    from lxml import etree
+
+    return etree.XMLParser(load_dtd=False, resolve_entities=True, no_network=True)
+
+
 def __extend_targets_sources(target, source):
     """ Prepare the lists of target and source files. """
     if not SCons.Util.is_List(target):
@@ -248,7 +274,7 @@ def __xml_scan(node, env, path, arg):
     from lxml import etree
 
     xsl_tree = etree.parse(xsl_file)
-    doc = etree.parse(str(node))
+    doc = etree.parse(str(node), _make_xml_parser())
     result = doc.xslt(xsl_tree)
 
     depfiles = [x.strip() for x in str(result).splitlines() if x.strip() != "" and not x.startswith("<?xml ")]
@@ -312,7 +338,7 @@ def __build_lxml(target, source, env):
     xsl_style = env.subst('$DOCBOOK_XSL')
     xsl_tree = etree.parse(xsl_style)
     transform = etree.XSLT(xsl_tree, access_control=xslt_ac)
-    doc = etree.parse(str(source[0]))
+    doc = etree.parse(str(source[0]), _make_xml_parser())
     # NOTE: if someone ever wants to pass XSLT params via DOCBOOK_XSLTPROCFLAGS
     # we should actually parse that here - look for --stringparam flags.
     parampass = {}
@@ -356,7 +382,7 @@ def __build_lxml_noresult(target, source, env):
     xsl_style = env.subst('$DOCBOOK_XSL')
     xsl_tree = etree.parse(xsl_style)
     transform = etree.XSLT(xsl_tree, access_control=xslt_ac)
-    doc = etree.parse(str(source[0]))
+    doc = etree.parse(str(source[0]), _make_xml_parser())
     # Support for additional parameters
     parampass = {}
     if parampass:
@@ -373,7 +399,7 @@ def __xinclude_lxml(target, source, env):
     """
     from lxml import etree
 
-    doc = etree.parse(str(source[0]))
+    doc = etree.parse(str(source[0]), _make_xml_parser())
     doc.xinclude()
     try:
         doc.write(str(target[0]), xml_declaration=True,
@@ -470,7 +496,7 @@ def DocbookEpub(env, target, source=None, *args, **kw):
         if has_lxml:
             from lxml import etree
 
-            opf = etree.parse(content_file)
+            opf = etree.parse(content_file, _make_xml_parser())
             # All the opf:item elements are resources
             for item in opf.xpath('//opf:item',
                     namespaces= { 'opf': 'http://www.idpf.org/2007/opf' }):

--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -176,6 +176,33 @@ def isSConsXml(fpath):
 
     return False
 
+def make_xml_parser():
+    """Return an XML parser set up to resolve the entities used by the docs.
+
+    The doc sources pull in their entity definitions through external
+    *parameter* entities (see DoctypeDeclaration below)::
+
+        <!DOCTYPE sconsdoc [
+            <!ENTITY % scons SYSTEM "../scons.mod">
+            %scons;
+
+    As of lxml 6.1.3 those are no longer resolved unless asked for explicitly
+    (see https://bugs.launchpad.net/lxml/+bug/2165901), so every parse of a doc
+    file has to be handed this parser - the default one fails with
+    "Entity 'scons' not defined".
+
+    resolve_entities=True is spelled as a bool on purpose: the string forms
+    ("internal"/"always") only exist from lxml 6.0 on, while the bool is
+    accepted by every version we support.
+
+    load_dtd stays False on purpose as well. It controls loading the *external*
+    DTD subset - the internal subset holding the entity declarations above is
+    read either way - and turning it on makes libxml2 try to fetch the remote
+    DTD of any document declaring one, which no_network then refuses.
+    """
+    return etree.XMLParser(load_dtd=False, resolve_entities=True, no_network=True)
+
+
 def remove_entities(content):
     # Cut out entity inclusions
     content = re_entity_header.sub("", content, re.M)
@@ -355,7 +382,7 @@ class TreeFactory:
         if TreeFactory.xmlschema is None:
             TreeFactory.xmlschema = etree.XMLSchema(xmlschema_context)
         try:
-            doc = etree.parse(fpath)
+            doc = etree.parse(fpath, make_xml_parser())
         except Exception as e:
             print(f"ERROR: {fpath} fails to parse:")
             print(e)
@@ -423,7 +450,7 @@ class SConsDocTree:
 
     def parseXmlFile(self, fpath):
         # Create domtree from file
-        parser = etree.XMLParser(load_dtd=True, resolve_entities=False)
+        parser = make_xml_parser()
         domtree = etree.parse(fpath, parser)
         self.root = domtree.getroot()
 

--- a/test/Docbook/basedir/slideshtml/image/xsltver.py
+++ b/test/Docbook/basedir/slideshtml/image/xsltver.py
@@ -5,20 +5,41 @@
 import os
 import re
 
+re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
+re_branch = re.compile(b"<fm:Branch>([^<]+)</fm:Branch>")
+
+# Lowest version the callers treat as namespace-aware. Used as a stand-in when
+# VERSION names the XSL-NS branch but carries a non-numeric version string.
+NS_VERSION = (1, 78, 0)
+
 def detectXsltVersion(fpath):
     """ Return a tuple with the version of the Docbook XSLT stylesheets,
         or (0, 0, 0) if no stylesheets are found or the VERSION
         file couldn't be found/parsed correctly.
-    """
-    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
-        re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
-        m = re_version.search(fin.read())
-        if m:
-            try:
-                return tuple(map(int, m.group(1).split(b'.')))
-            except Exception:
-                return (0, 0, 0)
 
+        Not every distribution puts a number in <fm:Version>: Debian and
+        Ubuntu's docbook-xsl 1.79.2 ships "snapshot" there. Callers only
+        use the result to decide whether the stylesheets are namespace
+        aware, and <fm:Branch> states that outright, so fall back to it
+        instead of reporting (0, 0, 0) - which would feed the plain,
+        non-namespaced input to namespace-aware stylesheets and quietly
+        produce an empty document.
+    """
+    try:
+        with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+            content = fin.read()
+    except OSError:
         return (0, 0, 0)
+
+    m = re_version.search(content)
+    if m:
+        try:
+            return tuple(map(int, m.group(1).split(b'.')))
+        except ValueError:
+            pass
+
+    m = re_branch.search(content)
+    if m and b'XSL-NS' in m.group(1):
+        return NS_VERSION
 
     return (0, 0, 0)

--- a/test/Docbook/basic/entities/entities.py
+++ b/test/Docbook/basic/entities/entities.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Test that a DocBook source pulling in an external entity module builds.
+
+lxml 6.1.3 stopped resolving external parameter entities by default
+(https://bugs.launchpad.net/lxml/+bug/2165901), which broke any document
+using the
+
+    <!ENTITY % myents SYSTEM "entities.mod">
+    %myents;
+
+idiom until the docbook tool started asking for entity resolution explicitly.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+try:
+    import lxml # noqa: F401
+except Exception:
+    test.skip_test('Cannot find installed Python binding for lxml, skipping test.\n')
+
+test.dir_fixture('image')
+
+# Normal invocation
+test.run()
+test.must_not_be_empty(test.workpath('manual_xi.xml'))
+test.must_contain(
+    test.workpath('manual_xi.xml'),
+    'This is text from an external entity module.',
+    mode='r',
+)
+
+# Cleanup
+test.run(arguments='-c')
+test.must_not_exist(test.workpath('manual_xi.xml'))
+
+test.pass_test()

--- a/test/Docbook/basic/entities/image/SConstruct
+++ b/test/Docbook/basic/entities/image/SConstruct
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
+env = Environment(tools=['docbook'])
+env.DocbookXInclude('manual_xi.xml', 'manual.xml')

--- a/test/Docbook/basic/entities/image/entities.mod
+++ b/test/Docbook/basic/entities/image/entities.mod
@@ -1,0 +1,1 @@
+<!ENTITY included-text "This is text from an external entity module.">

--- a/test/Docbook/basic/entities/image/manual.xml
+++ b/test/Docbook/basic/entities/image/manual.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-License-Identifier: MIT
+
+Copyright The SCons Foundation
+-->
+<!DOCTYPE article [
+  <!ENTITY % scons-ents SYSTEM "entities.mod">
+  %scons-ents;
+]>
+<article>
+  <title>External entity module test</title>
+
+  <section id="basics">
+    <title>Basics</title>
+
+    <para>&included-text;</para>
+  </section>
+
+</article>

--- a/test/Docbook/basic/slideshtml/image/xsltver.py
+++ b/test/Docbook/basic/slideshtml/image/xsltver.py
@@ -5,20 +5,41 @@
 import os
 import re
 
+re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
+re_branch = re.compile(b"<fm:Branch>([^<]+)</fm:Branch>")
+
+# Lowest version the callers treat as namespace-aware. Used as a stand-in when
+# VERSION names the XSL-NS branch but carries a non-numeric version string.
+NS_VERSION = (1, 78, 0)
+
 def detectXsltVersion(fpath):
     """ Return a tuple with the version of the Docbook XSLT stylesheets,
         or (0, 0, 0) if no stylesheets are found or the VERSION
         file couldn't be found/parsed correctly.
-    """
-    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
-        re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
-        m = re_version.search(fin.read())
-        if m:
-            try:
-                return tuple(map(int, m.group(1).split(b'.')))
-            except Exception:
-                return (0, 0, 0)
 
+        Not every distribution puts a number in <fm:Version>: Debian and
+        Ubuntu's docbook-xsl 1.79.2 ships "snapshot" there. Callers only
+        use the result to decide whether the stylesheets are namespace
+        aware, and <fm:Branch> states that outright, so fall back to it
+        instead of reporting (0, 0, 0) - which would feed the plain,
+        non-namespaced input to namespace-aware stylesheets and quietly
+        produce an empty document.
+    """
+    try:
+        with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+            content = fin.read()
+    except OSError:
         return (0, 0, 0)
+
+    m = re_version.search(content)
+    if m:
+        try:
+            return tuple(map(int, m.group(1).split(b'.')))
+        except ValueError:
+            pass
+
+    m = re_branch.search(content)
+    if m and b'XSL-NS' in m.group(1):
+        return NS_VERSION
 
     return (0, 0, 0)

--- a/test/Docbook/rootname/slideshtml/image/xsltver.py
+++ b/test/Docbook/rootname/slideshtml/image/xsltver.py
@@ -5,20 +5,41 @@
 import os
 import re
 
+re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
+re_branch = re.compile(b"<fm:Branch>([^<]+)</fm:Branch>")
+
+# Lowest version the callers treat as namespace-aware. Used as a stand-in when
+# VERSION names the XSL-NS branch but carries a non-numeric version string.
+NS_VERSION = (1, 78, 0)
+
 def detectXsltVersion(fpath):
     """ Return a tuple with the version of the Docbook XSLT stylesheets,
         or (0, 0, 0) if no stylesheets are found or the VERSION
         file couldn't be found/parsed correctly.
-    """
-    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
-        re_version = re.compile(b"<fm:Version>([^<]+)</fm:Version>")
-        m = re_version.search(fin.read())
-        if m:
-            try:
-                return tuple(map(int, m.group(1).split(b'.')))
-            except Exception:
-                return (0, 0, 0)
 
+        Not every distribution puts a number in <fm:Version>: Debian and
+        Ubuntu's docbook-xsl 1.79.2 ships "snapshot" there. Callers only
+        use the result to decide whether the stylesheets are namespace
+        aware, and <fm:Branch> states that outright, so fall back to it
+        instead of reporting (0, 0, 0) - which would feed the plain,
+        non-namespaced input to namespace-aware stylesheets and quietly
+        produce an empty document.
+    """
+    try:
+        with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+            content = fin.read()
+    except OSError:
         return (0, 0, 0)
+
+    m = re_version.search(content)
+    if m:
+        try:
+            return tuple(map(int, m.group(1).split(b'.')))
+        except ValueError:
+            pass
+
+    m = re_branch.search(content)
+    if m and b'XSL-NS' in m.group(1):
+        return NS_VERSION
 
     return (0, 0, 0)


### PR DESCRIPTION
lxml 6.1.3 fixed LP#2165901, which had allowed external *parameter* entities to be resolved under resolve_entities="internal" (the default since lxml 6.0). The fix disables the SAX getParameterEntity callback in that mode.

The SCons doc sources are built entirely on external parameter entities:

    <!DOCTYPE sconsdoc [
        <!ENTITY % scons SYSTEM "../scons.mod">
        %scons;

so on lxml 6.1.3+ every doc file failed with "Entity 'scons' not defined": bin/docs-validate.py failed on all 215 files and "scons doc" died building scons_xi.xml.

The breakage was in the bare etree.parse() calls that pass no parser and therefore inherit lxml's restrictive default. Two components were hit:

  * bin/SConsDoc.py - TreeFactory.validateXml() and SConsDocTree.parseXmlFile() now share a make_xml_parser() helper.

  * SCons/Tool/docbook/__init__.py - the shipped docbook tool, which is a user-facing regression: any user whose DocBook sources pull in an entity module failed to build. The five document parses now use a _make_xml_parser() helper; the stylesheet parses are left alone, as XSL files carry no entity modules.

The parser is XMLParser(load_dtd=False, resolve_entities=True, no_network=True). resolve_entities is spelled as a bool because the string forms only exist from lxml 6.0 on. load_dtd stays False deliberately: it controls the *external* DTD subset - the internal subset holding the entity declarations is read either way - and enabling it makes libxml2 try to fetch the remote DTD of any document declaring one, which breaks test/Docbook/basic/xinclude.

Adds test/Docbook/basic/entities, which builds a DocBook source using an external entity module; it fails without this change.

Verified on lxml 5.0.0, 5.4.0, 6.0.0, 6.1.2 and 6.1.3: docs-validate passes 215/215, "scons doc" produces all XInclude artifacts, and test/Docbook has the same pass/fail set as before the change. No lxml pin is needed, since one parser config covers the whole supported range.


Claude-Session: https://claude.ai/code/session_0189csDsnNi2NSKrNavwCA4f

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

https://scons.org/guidelines.html


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
